### PR TITLE
In order to make compatible with unix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply from: "${ext.ullinkGradleScripts}/task-rules.gradle"
 apply from: "${ext.ullinkGradleScripts}/functions.gradle"
 
 group = 'com.ullink.gradle'
-version = '1.0'
+version = '1.1'
 description 'gradle-nunit-plugin is a Gradle plugin that enables NUnit testing'
 
 dependencies {

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -47,14 +47,15 @@ class NUnit extends ConventionTask {
 
     @TaskAction
     def build() {
-        def commandLine = [nunitExec] + buildCommandArgs()
-        execute(commandLine)
+        execute([nunitExec.absolutePath], buildCommandArgs())
     }
 
-    def execute(commandLineArgs) {
+    def execute(commandLineExec, commandLineArgs) {
         prepareExecute()
+
         def mbr = project.exec {
-            commandLine = commandLineArgs
+            commandLine = commandLineExec
+            args = commandLineArgs
             ignoreExitValue = ignoreFailures
         }
 
@@ -89,11 +90,15 @@ class NUnit extends ConventionTask {
             }
         }
         if (verb) {
-            commandLineArgs += '/trace=' + verb
+            commandLineArgs += '-trace=' + verb
         }
-        commandLineArgs += '/xml:' + testReportPath
+        commandLineArgs += '-xml:' + testReportPath
         getTestAssemblies().each {
-            commandLineArgs += project.file(it)
+            def file = project.file(it)
+            if (file.exists() )
+                commandLineArgs += file
+            else
+                commandLineArgs += it
         }
         commandLineArgs
     }


### PR DESCRIPTION
- Commandline params "-" instead of "/"
- Separation of nunit commandline execution and args
- Version to 1.1
- Only prepend path to args which are file
