### PR TITLE
Fixed wrong interpretation of return value

### DIFF
--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -60,6 +60,9 @@ class NUnit extends ConventionTask {
         execute(cmdLine)
     }
 
+    // Return values of nunit v2 and v3 are defined in
+    // https://github.com/nunit/nunitv2/blob/master/src/ConsoleRunner/nunit-console/ConsoleUi.cs and
+    // https://github.com/nunit/nunit/blob/master/src/NUnitConsole/nunit-console/ConsoleRunner.cs
     def execute(commandLineExec) {
         prepareExecute()
 
@@ -68,17 +71,17 @@ class NUnit extends ConventionTask {
             ignoreExitValue = ignoreFailures
         }
 
-        switch (mbr.exitValue) {
-            case 0:
-            case 16:
-                break;
-            case 1: // nunit test failed
-                // ok & failure
-                if (ignoreFailures) break;
-            default:
-                // nok
-                throw new GradleException("${nunitExec} execution failed (ret=${mbr.exitValue})");
+        int exitValue = mbr.exitValue
+        if (exitValue == 0) {
+            return
         }
+
+        boolean anyTestFailing = exitValue > 0
+        if (anyTestFailing && ignoreFailures) {
+            return
+        }
+
+        throw new GradleException("${nunitExec} execution failed (ret=${mbr.exitValue})");
     }
 
     def prepareExecute() {


### PR DESCRIPTION
Hello

I think the plugin interprets the return values of the nunit console wrong:
- Given 4 tests fail, nunit will return 4 => the plugin will throw an exception, no matter if the _ignoreFailures_ option is set.
- The plugin distinguishes the magic values 16 and 1: I cannot find them in the documentation of nunit as special values.
- Reading http://stackoverflow.com/questions/3889577/does-anyone-know-where-to-find-nunit-console-exit-codes-meanings and https://github.com/nunit/nunitv2/blob/master/src/ConsoleRunner/nunit-console/ConsoleUi.cs, I guess the return values must be interpreted as follows:
  - 0: everything okay
  - > 0: some tests have failed
  - < 0: technical error

Matthias
