### PR TITLE
Adds additional parameters (runList, run, config, timeout)

### DIFF
--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -14,6 +14,10 @@ class NUnit extends ConventionTask {
     def exclude
     def framework
     def verbosity
+    def config
+    def timeout
+    def runList
+    def run
     boolean useX86 = false
     boolean noShadow = false
 
@@ -115,6 +119,18 @@ class NUnit extends ConventionTask {
         }
         if (noShadow) {
             commandLineArgs += '-noshadow'
+        }
+        if(runList) {
+            commandLineArgs += '-runList:' + runList
+        }
+        if(run){
+            commandLineArgs += '-run:' + run
+        }
+        if(config){
+            commandLineArgs += '-config:' + config
+        }
+        if(timeout){
+            commandLineArgs += '-timeout:' + timeout
         }
         commandLineArgs += '-xml:' + testReportPath
         getTestAssemblies().each {


### PR DESCRIPTION
This adds a few additional parameters to the plugin that may be useful for running tests under different configurations, running specific test suites in a dll or project, or adding a timeout to tests.
