### PR TITLE
be able to set the result output file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4
 ### Added
+* Support overriding the report file name
 * Added support for NUnit v3 (#11 #12)
 * Support overriding the report folder (#10)
 

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -26,7 +26,7 @@ class NUnit extends ConventionTask {
     def reportFolder
     boolean useX86 = false
     boolean shadowCopy = false
-
+    def reportFileName  = 'TestResult.xml'
     boolean ignoreFailures = false
 
     NUnit() {
@@ -65,7 +65,7 @@ class NUnit extends ConventionTask {
     }
 
     File getTestReportPath() {
-        new File(getReportFolderImpl(), 'TestResult.xml')
+        new File(getReportFolderImpl(), reportFileName)
     }
 
     @TaskAction


### PR DESCRIPTION
It's useful when we want run nunit for different namepsaces using
"run", for instance.
