### PR TITLE
Fix incorrect arg for setting test report path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # gradle-nunit-plugin changelog
 
 ## 1.5
+### Fixed
+* Fix NUnit v3 console argument in specifying test result output
 
 ## 1.4
 ### Added

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -185,7 +185,7 @@ class NUnit extends ConventionTask {
             commandLineArgs += "-timeout:$timeout"
         }
         if (isV3) {
-            commandLineArgs += "-out:$testReportPath"
+            commandLineArgs += "-result:$testReportPath"
         } else {
             commandLineArgs += "-xml:$testReportPath"
         }


### PR DESCRIPTION
-out is the `File PATH to contain text output from the tests.`
whereas 
-result is `An output SPEC for saving the test results`

references: [Nunit Wiki](https://github.com/nunit/nunit/wiki/Console-Command-Line)
