### PR TITLE
Added support for multiple namespaces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ description 'gradle-nunit-plugin is a Gradle plugin that enables NUnit testing'
 
 dependencies {
     compile 'de.undercouch:gradle-download-task:2.0.0'
+    compile 'org.codehaus.gpars:gpars:1.2.1'
 }
 
 bintray {

--- a/src/test/groovy/com/ullink/NUnitPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitPluginTest.groovy
@@ -73,6 +73,6 @@ class NUnitPluginTest {
             testAssemblies = ['TestA.dll']
             reportFolder = './foo'
         }
-        assertEquals('foo', project.nunit.testReportPath.parentFile.name)
+        assertEquals('foo', project.nunit.getTestReportPath('testA').parentFile.name)
     }
 }

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -44,9 +44,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = 'Test1'
-        nunit.reportFolder = 'c:\\'
+        nunit.reportFolder = '.\\'
 
-        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}\\TestResult.xml")]
     }
 
     @Test
@@ -55,9 +55,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = 'Test1'
-        nunit.reportFolder = 'c:\\'
+        nunit.reportFolder = '.\\'
 
-        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}\\TestResult.xml")]
     }
 
     @Test
@@ -66,9 +66,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = false
         nunit.run = ['Test1', 'Test2']
-        nunit.reportFolder = 'c:\\'
+        nunit.reportFolder = '.\\'
 
-        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}\\TestResult.xml")]
     }
 
     @Test
@@ -77,9 +77,10 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult_<<TEST_RESULT>>.xml'
         nunit.parallel_forks = true
         nunit.run = ['Test1', 'Test2']
-        nunit.reportFolder = 'c:\\'
+        nunit.reportFolder = '.\\'
 
-        assert nunit.getOutputFiles() == [new File('c:\\TestResult_Test1.xml'), new File('c:\\TestResult_Test2.xml')]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}\\TestResult_Test1.xml"),
+                                          new File("${nunit.project.projectDir}\\TestResult_Test2.xml")]
     }
 
     def getNUnitTask() {

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -44,9 +44,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = 'Test1'
-        nunit.reportFolder = '.\\'
+        nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}\\TestResult.xml")]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
     }
 
     @Test
@@ -55,9 +55,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = 'Test1'
-        nunit.reportFolder = '.\\'
+        nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}\\TestResult.xml")]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
     }
 
     @Test
@@ -66,9 +66,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = false
         nunit.run = ['Test1', 'Test2']
-        nunit.reportFolder = '.\\'
+        nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}\\TestResult.xml")]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
     }
 
     @Test
@@ -77,10 +77,10 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult_<<TEST_RESULT>>.xml'
         nunit.parallel_forks = true
         nunit.run = ['Test1', 'Test2']
-        nunit.reportFolder = '.\\'
+        nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}\\TestResult_Test1.xml"),
-                                          new File("${nunit.project.projectDir}\\TestResult_Test2.xml")]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult_Test1.xml"),
+                                          new File("${nunit.project.projectDir}/TestResult_Test2.xml")]
     }
 
     def getNUnitTask() {

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -1,0 +1,46 @@
+package com.ullink
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+public class NUnitTest {
+
+    @Test
+    public void getTestInputAsList_works() {
+        def nunit = getNUnitTask()
+        assert nunit.getTestInputAsList('A,B,C') == ['A', 'B', 'C']
+        assert nunit.getTestInputAsList('A') == ['A']
+        assert nunit.getTestInputAsList(['A', 'B', 'C']) == ['A', 'B', 'C']
+        assert nunit.getTestInputAsList(['A']) == ['A']
+        def emptyStringList = nunit.getTestInputAsList('')
+        assert (emptyStringList instanceof List)
+        assert !emptyStringList
+
+        def emptyListList = nunit.getTestInputAsList([])
+        assert (emptyListList instanceof List)
+        assert !emptyListList
+
+        def nullList = nunit.getTestInputAsList(null)
+        assert (nullList instanceof List)
+        assert !nullList
+    }
+
+    @Test
+    public void getTestInputsAsString_works() {
+        def nunit = getNUnitTask()
+        assert nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
+        assert nunit.getTestInputsAsString('A') == 'A'
+        assert nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A,B,C'
+        assert nunit.getTestInputsAsString(['A']) == 'A'
+        assert nunit.getTestInputsAsString('') == ''
+        assert nunit.getTestInputsAsString([]) == ''
+        assert nunit.getTestInputsAsString(null) == ''
+    }
+    }
+
+    def getNUnitTask() {
+        def project = ProjectBuilder.builder().build()
+        project.apply plugin: 'nunit'
+        return project.tasks.nunit
+    }
+}

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -12,6 +12,7 @@ public class NUnitTest {
         assert nunit.getTestInputAsList('A') == ['A']
         assert nunit.getTestInputAsList(['A', 'B', 'C']) == ['A', 'B', 'C']
         assert nunit.getTestInputAsList(['A']) == ['A']
+
         def emptyStringList = nunit.getTestInputAsList('')
         assert (emptyStringList instanceof List)
         assert !emptyStringList
@@ -36,6 +37,49 @@ public class NUnitTest {
         assert nunit.getTestInputsAsString([]) == ''
         assert nunit.getTestInputsAsString(null) == ''
     }
+
+    @Test
+    public void whenSingleTest_notParallel_singleOutputFile(){
+        def nunit = getNUnitTask()
+        nunit.reportFileName = 'TestResult.xml'
+        nunit.parallel_forks = true
+        nunit.run = 'Test1'
+        nunit.reportFolder = 'c:\\'
+
+        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+    }
+
+    @Test
+    public void whenSingleTest_Parallel_singleOutputFile(){
+        def nunit = getNUnitTask()
+        nunit.reportFileName = 'TestResult.xml'
+        nunit.parallel_forks = true
+        nunit.run = 'Test1'
+        nunit.reportFolder = 'c:\\'
+
+        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+    }
+
+    @Test
+    public void whenMultipleTests_notParallel_singleOutputFile(){
+        def nunit = getNUnitTask()
+        nunit.reportFileName = 'TestResult.xml'
+        nunit.parallel_forks = false
+        nunit.run = ['Test1', 'Test2']
+        nunit.reportFolder = 'c:\\'
+
+        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+    }
+
+    @Test
+    public void whenMultipleTests_Parallel_multipleOutputFiles(){
+        def nunit = getNUnitTask()
+        nunit.reportFileName = 'TestResult_<<TEST_RESULT>>.xml'
+        nunit.parallel_forks = true
+        nunit.run = ['Test1', 'Test2']
+        nunit.reportFolder = 'c:\\'
+
+        assert nunit.getOutputFiles() == [new File('c:\\TestResult_Test1.xml'), new File('c:\\TestResult_Test2.xml')]
     }
 
     def getNUnitTask() {


### PR DESCRIPTION
- You can set multiple test filters at the same time by setting them as a string (`run='Namespace1,Namespace2'`) or as a list (`run=['Namespace1', 'Namespace2']`)
  - You can set the property "parallel_forks" to true or false to control the parallel execution of the filters
  - if the filters are run in parallel you can specify the output files by using the template <<TEST_RESULT>> 
    (ex: `run=['Namespace1', 'Namespace2'] reportFileName = MyReport_<<TEST_RESULT>>.xml`) will output two files: MyReport_Namespace1.xml and MyReport_Namespace2.xml
