### PR TITLE
Add support for parallel test execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 * Fix NUnit v3 console argument in specifying test result output
 
+### Added
+* The `nuget-base` plugin allows proper NUnit-based tasks creation without creating the default `nunit` task
+
 ## 1.4
 ### Added
 * Support overriding the report file name

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ description 'gradle-nunit-plugin is a Gradle plugin that enables NUnit testing'
 dependencies {
     compile 'de.undercouch:gradle-download-task:2.0.0'
     compile 'org.codehaus.gpars:gpars:1.2.1'
+    testCompile 'xmlunit:xmlunit:1.6'
 }
 
 bintray {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ description 'gradle-nunit-plugin is a Gradle plugin that enables NUnit testing'
 
 dependencies {
     compile 'de.undercouch:gradle-download-task:2.0.0'
+    compile 'org.codehaus.gpars:gpars:1.2.1'
 }
 
 bintray {

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
@@ -1,0 +1,65 @@
+package com.ullink.gradle.nunit
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class NUnitBasePlugin implements Plugin<Project> {
+    void apply(Project project) {
+        project.apply plugin: 'de.undercouch.download'
+        project.tasks.withType(NUnit).whenTaskAdded { NUnit task ->
+            applyNunitConventions(task, project)
+        }
+    }
+
+    def applyNunitConventions(NUnit task, Project project) {
+        task.conventionMapping.map "nunitDownloadUrl", { "https://github.com/nunit/${task.isV3 ? 'nunit' : 'nunitv2'}/releases/download" }
+        task.conventionMapping.map "nunitVersion", { '2.6.4' }
+        task.conventionMapping.map "nunitHome", {
+            if (System.getenv()['NUNIT_HOME']) {
+                return System.getenv()['NUNIT_HOME']
+            }
+            downloadNUnit(project, task)
+        }
+        if (project.plugins.hasPlugin('msbuild')) {
+            task.dependsOn project.tasks.msbuild
+            task.conventionMapping.map "testAssemblies", {
+                project.tasks.msbuild.projects.findAll {
+                    it.key =~ 'test' && it.value.properties.TargetPath
+                }
+                .collect {
+                    it.value.getProjectPropertyPath('TargetPath')
+                }
+            }
+        }
+    }
+
+    File downloadNUnit(Project project, NUnit task) {
+        def version = task.getNunitVersion()
+        def nunitDowloadUrl = task.getNunitDownloadUrl()
+        def tempDir = task.getTemporaryDir()
+        def NUnitName = "NUnit-$version"
+        def NUnitZipFile = NUnitName + '.zip'
+        def downloadedFile = new File(tempDir, NUnitZipFile)
+        def nunitCacheDir = new File(new File(project.gradle.gradleUserHomeDir, 'caches'), 'nunit')
+        if (!nunitCacheDir.exists()) {
+            nunitCacheDir.mkdirs()
+        }
+        def nunitCacheDirForVersion = new File(nunitCacheDir, NUnitName)
+
+        // special handling for nunit3 flat zip file
+        def zipOutputDir = task.isV3 ? nunitCacheDirForVersion : nunitCacheDir;
+
+        def ret = nunitCacheDirForVersion
+        if (!ret.exists()) {
+            project.logger.info "Downloading & Unpacking NUnit ${version}"
+            project.download {
+                src "$nunitDowloadUrl/$version/$NUnitZipFile"
+                dest downloadedFile
+            }
+            project.copy {
+                from project.zipTree(downloadedFile)
+                into zipOutputDir
+            }
+        }
+        ret
+    }
+}

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitPlugin.groovy
@@ -1,74 +1,14 @@
 package com.ullink.gradle.nunit
 
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.tasks.Copy
-import de.undercouch.gradle.tasks.download.Download
 
 class NUnitPlugin implements Plugin<Project> {
-
     void apply(Project project) {
-        project.apply plugin: 'de.undercouch.download'
-        project.tasks.withType(NUnit).whenTaskAdded { NUnit task ->
-            applyNunitConventions(task, project)
-        }
+        project.apply plugin: 'nunit-base'
 
-        Task nunitTask = project.task('nunit', type: NUnit)
-        nunitTask.description = 'Executes NUnit tests'
-    }
-
-    def applyNunitConventions(NUnit task, Project project) {
-        task.conventionMapping.map "nunitDownloadUrl", { "https://github.com/nunit/${task.isV3 ? 'nunit' : 'nunitv2'}/releases/download" }
-        task.conventionMapping.map "nunitVersion", { '2.6.4' }
-        task.conventionMapping.map "nunitHome", {
-            if (System.getenv()['NUNIT_HOME']) {
-                return System.getenv()['NUNIT_HOME']
-            }
-            downloadNUnit(project, task)
-        }
-        if (project.plugins.hasPlugin('msbuild')) {
-            task.dependsOn project.tasks.msbuild
-            task.conventionMapping.map "testAssemblies", {
-                project.tasks.msbuild.projects.findAll {
-                    it.key =~ 'test' && it.value.properties.TargetPath
-                }
-                .collect {
-                    it.value.getProjectPropertyPath('TargetPath')
-                }
-            }
-        }
-    }
-
-    File downloadNUnit(Project project, NUnit task) {
-        def version = task.getNunitVersion()
-        def nunitDowloadUrl = task.getNunitDownloadUrl()
-        def tempDir = task.getTemporaryDir()
-        def NUnitName = "NUnit-$version"
-        def NUnitZipFile = NUnitName + '.zip'
-        def downloadedFile = new File(tempDir, NUnitZipFile)
-        def nunitCacheDir = new File(new File(project.gradle.gradleUserHomeDir, 'caches'), 'nunit')
-        if (!nunitCacheDir.exists()) {
-            nunitCacheDir.mkdirs()
-        }
-        def nunitCacheDirForVersion = new File(nunitCacheDir, NUnitName)
-
-        // special handling for nunit3 flat zip file
-        def zipOutputDir = task.isV3 ? nunitCacheDirForVersion : nunitCacheDir;
-
-        def ret = nunitCacheDirForVersion
-        if (!ret.exists()) {
-            project.logger.info "Downloading & Unpacking NUnit ${version}"
-            project.download {
-                src "$nunitDowloadUrl/$version/$NUnitZipFile"
-                dest downloadedFile
-            }
-            project.copy {
-                from project.zipTree(downloadedFile)
-                into zipOutputDir
-            }
-        }
-        ret
+        Task defaultNUnitTask = project.task('nunit', type: NUnit)
+        defaultNUnitTask.description = 'Executes NUnit tests'
     }
 }

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitTestResultsMerger.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitTestResultsMerger.groovy
@@ -1,0 +1,41 @@
+package com.ullink.gradle.nunit
+
+import groovy.xml.XmlUtil
+
+class NUnitTestResultsMerger {
+    String merge(List<String> stringTestResults) {
+        def testResults = stringTestResults.collect { new XmlParser().parseText(it) }
+        def firstTestResult = testResults.first()
+        def baseXml = new XmlParser().parseText(
+                '<test-results name="Merged results">' +
+                '   <test-suite type="Test Project" executed="True" name="" asserts="0">' +
+                '       <results/>' +
+                '  </test-suite>' +
+                '</test-results>'
+        )
+
+        baseXml.children().add(0, firstTestResult.environment.first())
+        baseXml.children().add(1, firstTestResult.'culture-info'.first())
+
+        def mergedResultsNode = baseXml.'test-suite'.results.first()
+        testResults.each { xml -> mergedResultsNode.append(xml.'test-suite') }
+
+        def attributes = ['total', 'errors', 'failures', 'not-run', 'inconclusive', 'skipped', 'invalid', 'ignored'];
+        attributes.each {
+            baseXml['@' + it] = testResults.inject(0) { r, node -> r + Integer.valueOf(node['@' + it] ?: 0) }
+        }
+
+        baseXml.@date = firstTestResult.@date
+        baseXml.@time = firstTestResult.@time
+
+        def mergedTestSuite = baseXml.'test-suite'
+        mergedTestSuite.@time = testResults.inject(0.0d) { r, node ->
+            r + Double.valueOf(node.'test-suite'.first().@time)
+        }
+        mergedTestSuite.@result = testResults.inject('Success') { r, node ->
+            r == 'Failure' ? r : node.'test-suite'.first().@result
+        }
+
+        return XmlUtil.serialize(baseXml)
+    }
+}

--- a/src/main/resources/META-INF/gradle-plugins/nunit-base.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nunit-base.properties
@@ -1,0 +1,1 @@
+implementation-class=com.ullink.gradle.nunit.NUnitBasePlugin

--- a/src/test/groovy/com/ullink/NUnitPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitPluginTest.groovy
@@ -73,6 +73,6 @@ class NUnitPluginTest {
             testAssemblies = ['TestA.dll']
             reportFolder = './foo'
         }
-        assertEquals('foo', project.nunit.getTestReportPath('testA').parentFile.name)
+        assertEquals('foo', project.nunit.testReportPath.parentFile.name)
     }
 }

--- a/src/test/groovy/com/ullink/NUnitPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitPluginTest.groovy
@@ -73,6 +73,6 @@ class NUnitPluginTest {
             testAssemblies = ['TestA.dll']
             reportFolder = './foo'
         }
-        assertEquals('foo', project.nunit.testReportPath.parentFile.name)
+        assertEquals('foo', project.nunit.getTestReportPath('testA').parentFile.name)
     }
 }

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -44,9 +44,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = 'Test1'
-        nunit.reportFolder = 'c:\\'
+        nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
     }
 
     @Test
@@ -55,9 +55,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = 'Test1'
-        nunit.reportFolder = 'c:\\'
+        nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
     }
 
     @Test
@@ -66,9 +66,9 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = false
         nunit.run = ['Test1', 'Test2']
-        nunit.reportFolder = 'c:\\'
+        nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
     }
 
     @Test
@@ -77,9 +77,10 @@ public class NUnitTest {
         nunit.reportFileName = 'TestResult_<<TEST_RESULT>>.xml'
         nunit.parallel_forks = true
         nunit.run = ['Test1', 'Test2']
-        nunit.reportFolder = 'c:\\'
+        nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File('c:\\TestResult_Test1.xml'), new File('c:\\TestResult_Test2.xml')]
+        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult_Test1.xml"),
+                                          new File("${nunit.project.projectDir}/TestResult_Test2.xml")]
     }
 
     def getNUnitTask() {

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -39,48 +39,47 @@ public class NUnitTest {
     }
 
     @Test
-    public void whenSingleTest_notParallel_singleOutputFile(){
+    public void whenSingleTest_notParallel_singleTestReport(){
         def nunit = getNUnitTask()
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = 'Test1'
         nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
+        assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
     }
 
     @Test
-    public void whenSingleTest_Parallel_singleOutputFile(){
+    public void whenSingleTest_Parallel_singleTestReport(){
         def nunit = getNUnitTask()
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = 'Test1'
         nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
+        assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
     }
 
     @Test
-    public void whenMultipleTests_notParallel_singleOutputFile(){
+    public void whenMultipleTests_notParallel_singleTestReport(){
         def nunit = getNUnitTask()
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = false
         nunit.run = ['Test1', 'Test2']
         nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult.xml")]
+        assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
     }
 
     @Test
-    public void whenMultipleTests_Parallel_multipleOutputFiles(){
+    public void whenMultipleTests_parallel_singleTestReport(){
         def nunit = getNUnitTask()
-        nunit.reportFileName = 'TestResult_<<TEST_RESULT>>.xml'
+        nunit.reportFileName = 'TestResult.xml'
         nunit.parallel_forks = true
         nunit.run = ['Test1', 'Test2']
         nunit.reportFolder = './'
 
-        assert nunit.getOutputFiles() == [new File("${nunit.project.projectDir}/TestResult_Test1.xml"),
-                                          new File("${nunit.project.projectDir}/TestResult_Test2.xml")]
+        assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
     }
 
     def getNUnitTask() {

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -1,0 +1,46 @@
+package com.ullink
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+public class NUnitTest {
+
+    @Test
+    public void getTestInputAsList_works() {
+        def nunit = getNUnitTask()
+        assert nunit.getTestInputAsList('A,B,C') == ['A', 'B', 'C']
+        assert nunit.getTestInputAsList('A') == ['A']
+        assert nunit.getTestInputAsList(['A', 'B', 'C']) == ['A', 'B', 'C']
+        assert nunit.getTestInputAsList(['A']) == ['A']
+        def emptyStringList = nunit.getTestInputAsList('')
+        assert (emptyStringList instanceof List)
+        assert !emptyStringList
+
+        def emptyListList = nunit.getTestInputAsList([])
+        assert (emptyListList instanceof List)
+        assert !emptyListList
+
+        def nullList = nunit.getTestInputAsList(null)
+        assert (nullList instanceof List)
+        assert !nullList
+    }
+
+    @Test
+    public void getTestInputsAsString_works() {
+        def nunit = getNUnitTask()
+        assert nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
+        assert nunit.getTestInputsAsString('A') == 'A'
+        assert nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A,B,C'
+        assert nunit.getTestInputsAsString(['A']) == 'A'
+        assert nunit.getTestInputsAsString('') == ''
+        assert nunit.getTestInputsAsString([]) == ''
+        assert nunit.getTestInputsAsString(null) == ''
+    }
+    }
+
+    def getNUnitTask() {
+        def project = ProjectBuilder.builder().build()
+        project.apply plugin: 'nunit'
+        return project.tasks.nunit
+    }
+}

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -12,6 +12,7 @@ public class NUnitTest {
         assert nunit.getTestInputAsList('A') == ['A']
         assert nunit.getTestInputAsList(['A', 'B', 'C']) == ['A', 'B', 'C']
         assert nunit.getTestInputAsList(['A']) == ['A']
+
         def emptyStringList = nunit.getTestInputAsList('')
         assert (emptyStringList instanceof List)
         assert !emptyStringList
@@ -36,6 +37,49 @@ public class NUnitTest {
         assert nunit.getTestInputsAsString([]) == ''
         assert nunit.getTestInputsAsString(null) == ''
     }
+
+    @Test
+    public void whenSingleTest_notParallel_singleOutputFile(){
+        def nunit = getNUnitTask()
+        nunit.reportFileName = 'TestResult.xml'
+        nunit.parallel_forks = true
+        nunit.run = 'Test1'
+        nunit.reportFolder = 'c:\\'
+
+        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+    }
+
+    @Test
+    public void whenSingleTest_Parallel_singleOutputFile(){
+        def nunit = getNUnitTask()
+        nunit.reportFileName = 'TestResult.xml'
+        nunit.parallel_forks = true
+        nunit.run = 'Test1'
+        nunit.reportFolder = 'c:\\'
+
+        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+    }
+
+    @Test
+    public void whenMultipleTests_notParallel_singleOutputFile(){
+        def nunit = getNUnitTask()
+        nunit.reportFileName = 'TestResult.xml'
+        nunit.parallel_forks = false
+        nunit.run = ['Test1', 'Test2']
+        nunit.reportFolder = 'c:\\'
+
+        assert nunit.getOutputFiles() == [new File('c:\\TestResult.xml')]
+    }
+
+    @Test
+    public void whenMultipleTests_Parallel_multipleOutputFiles(){
+        def nunit = getNUnitTask()
+        nunit.reportFileName = 'TestResult_<<TEST_RESULT>>.xml'
+        nunit.parallel_forks = true
+        nunit.run = ['Test1', 'Test2']
+        nunit.reportFolder = 'c:\\'
+
+        assert nunit.getOutputFiles() == [new File('c:\\TestResult_Test1.xml'), new File('c:\\TestResult_Test2.xml')]
     }
 
     def getNUnitTask() {

--- a/src/test/groovy/com/ullink/NUnitTestResultsMergerTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTestResultsMergerTest.groovy
@@ -18,8 +18,6 @@ class NUnitTestResultsMergerTest {
 
         String testResult = new NUnitTestResultsMerger().merge(testResults)
 
-        System.err.println(testResult)
-
         XMLUnit.setIgnoreComments(true)
         XMLUnit.setIgnoreWhitespace(true)
         XMLUnit.setIgnoreAttributeOrder(true)
@@ -27,7 +25,7 @@ class NUnitTestResultsMergerTest {
                 getTestResult('TestResults_merged'),
                 testResult)
         diff.overrideElementQualifier(new RecursiveElementNameAndTextQualifier());
-        Assert.assertEquals(String.join('\n', new DetailedDiff(diff).allDifferences.collect {it.toString()}), "");
+        Assert.assertEquals('', new DetailedDiff(diff).allDifferences.join('\n'));
     }
 
     private String getTestResult(String fileName) {

--- a/src/test/groovy/com/ullink/NUnitTestResultsMergerTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTestResultsMergerTest.groovy
@@ -1,0 +1,36 @@
+package com.ullink
+import com.ullink.gradle.nunit.NUnitTestResultsMerger
+import org.custommonkey.xmlunit.DetailedDiff
+import org.custommonkey.xmlunit.XMLUnit
+import org.custommonkey.xmlunit.examples.RecursiveElementNameAndTextQualifier
+import org.junit.Assert
+import org.junit.Test
+
+class NUnitTestResultsMergerTest {
+    @Test
+    public void givenMultipleTestResultFilesForSameAssembly_merge_mergesIntoExpectedOutputResult()
+    {
+        def testResults = [
+                'TestResult_integrationTest_ILRepack.IntegrationTests.NuGet',
+                'TestResult_integrationTest_ILRepack.IntegrationTests.WPF',
+                'TestResult_unitTests'
+                ].collect { getTestResult(it) }
+
+        String testResult = new NUnitTestResultsMerger().merge(testResults)
+
+        System.err.println(testResult)
+
+        XMLUnit.setIgnoreComments(true)
+        XMLUnit.setIgnoreWhitespace(true)
+        XMLUnit.setIgnoreAttributeOrder(true)
+        def diff = XMLUnit.compareXML(
+                getTestResult('TestResults_merged'),
+                testResult)
+        diff.overrideElementQualifier(new RecursiveElementNameAndTextQualifier());
+        Assert.assertEquals(String.join('\n', new DetailedDiff(diff).allDifferences.collect {it.toString()}), "");
+    }
+
+    private String getTestResult(String fileName) {
+        getClass().getResource("/sample-testresults/${fileName}.xml").text
+    }
+}

--- a/src/test/resources/sample-testresults/TestResult_integrationTest_ILRepack.IntegrationTests.NuGet.xml
+++ b/src/test/resources/sample-testresults/TestResult_integrationTest_ILRepack.IntegrationTests.NuGet.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="E:\src\p\il-repack\ILRepack.IntegrationTests\bin\Release\ILRepack.IntegrationTests.dll" total="13" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2016-01-19" time="13:25:39">
+  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8670" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="E:\src\p\il-repack" machine-name="machinename" user="username" user-domain="domain" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="E:\src\p\il-repack\ILRepack.IntegrationTests\bin\Release\ILRepack.IntegrationTests.dll" executed="True" result="Success" success="True" time="123.035" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="ILRepack" executed="True" result="Success" success="True" time="123.028" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="IntegrationTests" executed="True" result="Success" success="True" time="123.028" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="NuGet" executed="True" result="Success" success="True" time="123.028" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="RepackNuGetTests" executed="True" result="Success" success="True" time="123.027" asserts="0">
+                    <results>
+                      <test-suite type="ParameterizedTest" name="NupkgPlatform" executed="True" result="Success" success="True" time="114.464" asserts="0">
+                        <categories>
+                          <category name="LongRunning" />
+                        </categories>
+                        <results>
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(UnionArgParser:0.8.7,FSharp.Core:3.0.2)" executed="True" result="Success" success="True" time="3.651" asserts="3">
+                            <categories>
+                              <category name="ComplexTests" />
+                            </categories>
+                          </test-case>
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(UnionArgParser:0.8.7,FSharp.Core:3.0.2)" executed="True" result="Success" success="True" time="2.868" asserts="3">
+                            <categories>
+                              <category name="ComplexTests" />
+                            </categories>
+                          </test-case>
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(MassTransit:2.9.9,Magnum:2.1.3,Newtonsoft.Json:6.0.8)" executed="True" result="Success" success="True" time="7.779" asserts="3">
+                            <categories>
+                              <category name="ComplexTests" />
+                            </categories>
+                          </test-case>
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(MassTransit:2.9.9,Magnum:2.1.3,Newtonsoft.Json:6.0.8)" executed="True" result="Success" success="True" time="5.489" asserts="3">
+                            <categories>
+                              <category name="ComplexTests" />
+                            </categories>
+                          </test-case>
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(Paket.Core:1.11.6,FSharp.Core:3.1.2.1)" executed="True" result="Success" success="True" time="8.046" asserts="3">
+                            <categories>
+                              <category name="ComplexTests" />
+                            </categories>
+                          </test-case>
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(FSharp.Compiler.Service:1.4.0.6,FSharp.Core:4.0.0.1)" executed="True" result="Success" success="True" time="86.619" asserts="3">
+                            <categories>
+                              <category name="ComplexTests" />
+                            </categories>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="RoundtripNupkg" executed="True" result="Success" success="True" time="6.525" asserts="0">
+                        <results>
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(Antlr:3.5.0.2)" executed="True" result="Success" success="True" time="1.198" asserts="2" />
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(Autofac:3.5.2)" executed="True" result="Success" success="True" time="0.721" asserts="2" />
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(AutoMapper:3.3.1)" executed="True" result="Success" success="True" time="1.084" asserts="3" />
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(MahApps.Metro:1.1.2)" executed="True" result="Success" success="True" time="2.665" asserts="5" />
+                          <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(Microsoft.Bcl.Async:1.0.168)" executed="True" result="Success" success="True" time="0.853" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.VerifiesMergedSignedAssemblyHasNoUnsignedFriend" executed="True" result="Success" success="True" time="1.248" asserts="3" />
+                      <test-case name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.VerifiesMergesBclFine" executed="True" result="Success" success="True" time="0.779" asserts="4" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test/resources/sample-testresults/TestResult_integrationTest_ILRepack.IntegrationTests.WPF.xml
+++ b/src/test/resources/sample-testresults/TestResult_integrationTest_ILRepack.IntegrationTests.WPF.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="E:\src\p\il-repack\ILRepack.IntegrationTests\bin\Release\ILRepack.IntegrationTests.dll" total="6" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2016-01-19" time="13:25:43">
+  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8670" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="E:\src\p\il-repack" machine-name="machinename" user="username" user-domain="domain" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="E:\src\p\il-repack\ILRepack.IntegrationTests\bin\Release\ILRepack.IntegrationTests.dll" executed="True" result="Failure" success="False" time="2.561" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="ILRepack" executed="True" result="Failure" success="False" time="2.554" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="IntegrationTests" executed="True" result="Failure" success="False" time="2.554" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="WPF" executed="True" result="Failure" success="False" time="2.554" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="WPFScenarios" executed="True" result="Failure" success="False" time="2.553" asserts="0">
+                    <results>
+                      <test-case name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenApplicationThatUsesThemingAndStylesFromA_MergedWPFApplicationRunsSuccessfully" executed="True" result="Success" success="True" time="0.343" asserts="3" />
+                      <test-case name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenSampleApplicationWithMahAppsAndSystemWindowsInteractivityWPF_MergedWPFApplicationRunsSuccessfully" executed="True" result="Success" success="True" time="1.334" asserts="3" />
+                      <test-case name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenTrue_ThisTestFails" executed="True" result="Failure" success="False" time="0.006" asserts="1">
+                        <failure>
+                          <message><![CDATA[  Expected: False
+  But was:  True
+]]></message>
+                          <stack-trace><![CDATA[]]></stack-trace>
+                        </failure>
+                      </test-case>
+                      <test-case name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenXAMLThatUsesLibraryClass_MergedWPFApplicationRunsSuccessfully" executed="True" result="Success" success="True" time="0.283" asserts="3" />
+                      <test-case name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenXAMLThatUsesLibraryUserControl_MergedWPFApplicationRunsSuccessfully" executed="True" result="Success" success="True" time="0.298" asserts="3" />
+                      <test-case name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenXAMLThatUsesNestedLibraryUserControlAndClass_MergedWPFApplicationRunsSuccessfully" executed="True" result="Success" success="True" time="0.269" asserts="3" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test/resources/sample-testresults/TestResult_unitTests.xml
+++ b/src/test/resources/sample-testresults/TestResult_unitTests.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="E:\src\p\il-repack\ILRepack.Tests\bin\Release\ILRepack.Tests.dll" total="68" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2016-01-19" time="13:25:45">
+  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8670" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="E:\src\p\il-repack" machine-name="machinename" user="username" user-domain="domain" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="E:\src\p\il-repack\ILRepack.Tests\bin\Release\ILRepack.Tests.dll" executed="True" result="Success" success="True" time="1.080" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="ILRepack" executed="True" result="Success" success="True" time="1.073" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.073" asserts="0">
+            <results>
+              <test-suite type="TestFixture" name="CommandLineTests" executed="True" result="Success" success="True" time="0.054" asserts="0">
+                <results>
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithArguments__GetCount__ReturnCount" executed="True" result="Success" success="True" time="0.018" asserts="2" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithBoolOption__GetOption__ReturnOption" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithEmptyOption__GetOption__ReturnEmptyString" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithEmptyOption__GetOption__ReturnNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithInvalidOptionPrefix__GetOption__ReturnNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithNoArguments__NewObject__NoOtherArguments" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithOneOption__NewObject__ReturnOption" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithOptions__RemoveOption__ReturnAllOptionsExceptTheOneRemoved" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithOptions__RemoveOptions__ReturnMatchedOptions" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithOptionWithInvalidAssignChar__GetOption__ReturnNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithValidOption__GetOptionWithNameInCaps__ReturnOption" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithValidOption__GetOtherOption__ReturnNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithValidOptionPrefix__GetOption__ReturnNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                  <test-case name="ILRepack.Tests.CommandLineTests.WithZeroArguments__GetIsEmpty__ReturnTrue" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                </results>
+              </test-suite>
+              <test-suite type="TestFixture" name="RepackLoggerTests" executed="True" result="Success" success="True" time="0.051" asserts="0">
+                <results>
+                  <test-case name="ILRepack.Tests.RepackLoggerTests.GivenAnEmptyOutputFile__OpenFile_CloseFile__OpenReturnsFalse_ClosedDoesNotThrowError" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackLoggerTests.GivenAnEmptyOutputFile__OpenFile_LogLine__OpenReturnsFalse_LogDoesNotThrowError" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackLoggerTests.GivenOutputFile__OpenFile_CloseFile_LogError__StreamIsOpened_StreamIsClosed_NoErrorIsThrown" executed="True" result="Success" success="True" time="0.046" asserts="1" />
+                </results>
+              </test-suite>
+              <test-suite type="TestFixture" name="RepackOptionsTests" executed="True" result="Success" success="True" time="0.453" asserts="0">
+                <results>
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithAllowDuplicateResources__GetModifier__ReturnModifier" executed="True" result="Success" success="True" time="0.311" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithAllowDuplicateTypes_WithNamespaces__CallParse__NamespacesAreSet" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithAllowDuplicateTypes_WithNamespaces_WithTypes__CallParse__TypesAndNamespacesAreSet" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithAllowDuplicateTypes_WithTypes__CallParse__DuplicateTypesAreSet" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithAllowMultipleAssign_WithNoCopyAttributes__Parse__ThrowsInvalidOperationException" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithAttributeFile_WithCopyAttributes__Parse__ThrowsInvalidOperationException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithHelpModifierh__CallShouldShowUsage__ReturnTrue" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithHelpModifierHelp__CallShouldShowUsage__ReturnTrue" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithHelpModifierQuestionMark__CallShouldShowUsage__ReturnTrue" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithModifierNDebug__Parse__DebugInfoFalseIsSet" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                  <test-suite type="ParameterizedTest" name="WithModifierTargetVersion__Parse__TargetPlatformVersionIsSet" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                    <results>
+                      <test-case name="ILRepack.Tests.RepackOptionsTests.WithModifierTargetVersion__Parse__TargetPlatformVersionIsSet(&quot;v2&quot;)" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                      <test-case name="ILRepack.Tests.RepackOptionsTests.WithModifierTargetVersion__Parse__TargetPlatformVersionIsSet(&quot;v4&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithNoInputAssemblies__ParseProperties__ThrowException" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithNoKeyFile__ParseProperties__ReadExcludeInternalizedMatches" executed="True" result="Success" success="True" time="0.063" asserts="3" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithNoKeyFile__ParseProperties__ThrowException" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithNoOptions_CallShouldShowUsage__ReturnTrue" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionInternalize__Parse__ExcludeFileIsSet" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionKeyFileNotSet_WithDelaySign__Parse__ThrowsInvalidOperationException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionLog__Parse__LogFileIsSet" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptions_CallShouldShowUsage__ReturnFalse" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetKindEXE__Parse__TargetKindIsSet" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetKindInvalid__Parse__TargetKindIsSet" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetKindLibrary__Parse__TargetKindIsSet" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetKindWinEXE__Parse__TargetKindIsSet" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetPlatform__Parse__DirectoryAndVersionAreSet" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetPlatform__Parse__VersionIsSet" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                  <test-case name="ILRepack.Tests.RepackOptionsTests.WithOptionVersion__Parse__VersionIsSet" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                </results>
+              </test-suite>
+              <test-suite type="Namespace" name="Steps" executed="True" result="Success" success="True" time="0.508" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="ResourceProcessing" executed="True" result="Success" success="True" time="0.495" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="BamlGeneratorTests" executed="True" result="Success" success="True" time="0.495" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="AddMergedDictionaries_GivenExistingGenericXaml_CreatesExpectedXaml" executed="True" result="Success" success="True" time="0.472" asserts="0">
+                            <results>
+                              <test-case name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.AddMergedDictionaries_GivenExistingGenericXaml_CreatesExpectedXaml(&quot;EmptyResourceDictionary/Start.xaml&quot;,&quot;EmptyResourceDictionary/End.xaml&quot;)" executed="True" result="Success" success="True" time="0.442" asserts="2" />
+                              <test-case name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.AddMergedDictionaries_GivenExistingGenericXaml_CreatesExpectedXaml(&quot;NonExistingMergedDictionaries/Start.xaml&quot;,&quot;NonExistingMergedDictionaries/End.xaml&quot;)" executed="True" result="Success" success="True" time="0.013" asserts="2" />
+                              <test-case name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.AddMergedDictionaries_GivenExistingGenericXaml_CreatesExpectedXaml(&quot;ExistingMergedDictionaries/Start.xaml&quot;,&quot;ExistingMergedDictionaries/End.xaml&quot;)" executed="True" result="Success" success="True" time="0.016" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.AddMergedDictionaries_GivenExistingGenericXamlThatIsNotAResourceDictionary_LogsErrorAndReturnsSameBaml" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.GenerateThemesGenericXaml_GivenIncludedXamlFiles_GeneratesSameBamlAsSample" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="XamlResourcePathPatcherStepTests" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                    <results>
+                      <test-suite type="ParameterizedTest" name="PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;pack://application:,,,/ClassLibrary;component/TextBlockStyles.xaml&quot;,&quot;pack://application:,,,/MainAssembly;component/ClassLibrary/TextBlockStyles.xaml&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/MainAssembly;component/ButtonStyles.xaml&quot;,&quot;/MainAssembly;component/ButtonStyles.xaml&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/ClassLibrary;component/ButtonStyles.xaml&quot;,&quot;/MainAssembly;component/ClassLibrary/ButtonStyles.xaml&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/themes/ButtonStyles.xaml&quot;,&quot;/themes/ButtonStyles.xaml&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;&quot;,&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;asdasd&quot;,&quot;asdasd&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/lol&quot;,&quot;/lol&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;123&quot;,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/ClassLibrary&quot;,&quot;/ClassLibrary&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;pack://application:,,,/ClassLibrary;component/TextBlockStyles.xaml&quot;,&quot;pack://application:,,,/MainAssembly;component/ClassLibrary/TextBlockStyles.xaml&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;/ClassLibrary;component/ButtonStyles.xaml&quot;,&quot;/MainAssembly;component/ClassLibrary/ButtonStyles.xaml&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;/themes/ButtonStyles.xaml&quot;,&quot;/ClassLibrary/themes/ButtonStyles.xaml&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;&quot;,&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;asdasd&quot;,&quot;asdasd&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;/lol&quot;,&quot;/lol&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;123&quot;,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;/ClassLibrary&quot;,&quot;/ClassLibrary&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test/resources/sample-testresults/TestResults_merged.xml
+++ b/src/test/resources/sample-testresults/TestResults_merged.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results date="2016-01-19" errors="0" failures="1" ignored="0" inconclusive="0" invalid="0" name="Merged results" not-run="0" skipped="0" time="13:25:39" total="87">
+  <environment clr-version="2.0.50727.8670" cwd="E:\src\p\il-repack" machine-name="machinename" nunit-version="2.6.4.14350" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" user="username" user-domain="domain"/>
+  <culture-info current-culture="en-US" current-uiculture="en-US"/>
+  <test-suite asserts="0" executed="True" name="" result="Failure" time="126.676" type="Test Project">
+    <results>
+      <test-suite asserts="0" executed="True" name="E:\src\p\il-repack\ILRepack.IntegrationTests\bin\Release\ILRepack.IntegrationTests.dll" result="Success" success="True" time="123.035" type="Assembly">
+        <results>
+          <test-suite asserts="0" executed="True" name="ILRepack" result="Success" success="True" time="123.028" type="Namespace">
+            <results>
+              <test-suite asserts="0" executed="True" name="IntegrationTests" result="Success" success="True" time="123.028" type="Namespace">
+                <results>
+                  <test-suite asserts="0" executed="True" name="NuGet" result="Success" success="True" time="123.028" type="Namespace">
+                    <results>
+                      <test-suite asserts="0" executed="True" name="RepackNuGetTests" result="Success" success="True" time="123.027" type="TestFixture">
+                        <results>
+                          <test-suite asserts="0" executed="True" name="NupkgPlatform" result="Success" success="True" time="114.464" type="ParameterizedTest">
+                            <categories>
+                              <category name="LongRunning"/>
+                            </categories>
+                            <results>
+                              <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(UnionArgParser:0.8.7,FSharp.Core:3.0.2)" result="Success" success="True" time="3.651">
+                                <categories>
+                                  <category name="ComplexTests"/>
+                                </categories>
+                              </test-case>
+                              <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(UnionArgParser:0.8.7,FSharp.Core:3.0.2)" result="Success" success="True" time="2.868">
+                                <categories>
+                                  <category name="ComplexTests"/>
+                                </categories>
+                              </test-case>
+                              <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(MassTransit:2.9.9,Magnum:2.1.3,Newtonsoft.Json:6.0.8)" result="Success" success="True" time="7.779">
+                                <categories>
+                                  <category name="ComplexTests"/>
+                                </categories>
+                              </test-case>
+                              <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(MassTransit:2.9.9,Magnum:2.1.3,Newtonsoft.Json:6.0.8)" result="Success" success="True" time="5.489">
+                                <categories>
+                                  <category name="ComplexTests"/>
+                                </categories>
+                              </test-case>
+                              <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(Paket.Core:1.11.6,FSharp.Core:3.1.2.1)" result="Success" success="True" time="8.046">
+                                <categories>
+                                  <category name="ComplexTests"/>
+                                </categories>
+                              </test-case>
+                              <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.NupkgPlatform(FSharp.Compiler.Service:1.4.0.6,FSharp.Core:4.0.0.1)" result="Success" success="True" time="86.619">
+                                <categories>
+                                  <category name="ComplexTests"/>
+                                </categories>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                          <test-suite asserts="0" executed="True" name="RoundtripNupkg" result="Success" success="True" time="6.525" type="ParameterizedTest">
+                            <results>
+                              <test-case asserts="2" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(Antlr:3.5.0.2)" result="Success" success="True" time="1.198"/>
+                              <test-case asserts="2" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(Autofac:3.5.2)" result="Success" success="True" time="0.721"/>
+                              <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(AutoMapper:3.3.1)" result="Success" success="True" time="1.084"/>
+                              <test-case asserts="5" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(MahApps.Metro:1.1.2)" result="Success" success="True" time="2.665"/>
+                              <test-case asserts="4" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.RoundtripNupkg(Microsoft.Bcl.Async:1.0.168)" result="Success" success="True" time="0.853"/>
+                            </results>
+                          </test-suite>
+                          <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.VerifiesMergedSignedAssemblyHasNoUnsignedFriend" result="Success" success="True" time="1.248"/>
+                          <test-case asserts="4" executed="True" name="ILRepack.IntegrationTests.NuGet.RepackNuGetTests.VerifiesMergesBclFine" result="Success" success="True" time="0.779"/>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite asserts="0" executed="True" name="E:\src\p\il-repack\ILRepack.IntegrationTests\bin\Release\ILRepack.IntegrationTests.dll" result="Failure" success="False" time="2.561" type="Assembly">
+        <results>
+          <test-suite asserts="0" executed="True" name="ILRepack" result="Failure" success="False" time="2.554" type="Namespace">
+            <results>
+              <test-suite asserts="0" executed="True" name="IntegrationTests" result="Failure" success="False" time="2.554" type="Namespace">
+                <results>
+                  <test-suite asserts="0" executed="True" name="WPF" result="Failure" success="False" time="2.554" type="Namespace">
+                    <results>
+                      <test-suite asserts="0" executed="True" name="WPFScenarios" result="Failure" success="False" time="2.553" type="TestFixture">
+                        <results>
+                          <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenApplicationThatUsesThemingAndStylesFromA_MergedWPFApplicationRunsSuccessfully" result="Success" success="True" time="0.343"/>
+                          <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenSampleApplicationWithMahAppsAndSystemWindowsInteractivityWPF_MergedWPFApplicationRunsSuccessfully" result="Success" success="True" time="1.334"/>
+                          <test-case asserts="1" executed="True" name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenTrue_ThisTestFails" result="Failure" success="False" time="0.006">
+                            <failure>
+                              <message><![CDATA[  Expected: False
+  But was:  True
+]]></message>
+                              <stack-trace><![CDATA[]]></stack-trace>
+                            </failure>
+                          </test-case>
+                          <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenXAMLThatUsesLibraryClass_MergedWPFApplicationRunsSuccessfully" result="Success" success="True" time="0.283"/>
+                          <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenXAMLThatUsesLibraryUserControl_MergedWPFApplicationRunsSuccessfully" result="Success" success="True" time="0.298"/>
+                          <test-case asserts="3" executed="True" name="ILRepack.IntegrationTests.WPF.WPFScenarios.GivenXAMLThatUsesNestedLibraryUserControlAndClass_MergedWPFApplicationRunsSuccessfully" result="Success" success="True" time="0.269"/>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite asserts="0" executed="True" name="E:\src\p\il-repack\ILRepack.Tests\bin\Release\ILRepack.Tests.dll" result="Success" success="True" time="1.080" type="Assembly">
+        <results>
+          <test-suite asserts="0" executed="True" name="ILRepack" result="Success" success="True" time="1.073" type="Namespace">
+            <results>
+              <test-suite asserts="0" executed="True" name="Tests" result="Success" success="True" time="1.073" type="Namespace">
+                <results>
+                  <test-suite asserts="0" executed="True" name="CommandLineTests" result="Success" success="True" time="0.054" type="TestFixture">
+                    <results>
+                      <test-case asserts="2" executed="True" name="ILRepack.Tests.CommandLineTests.WithArguments__GetCount__ReturnCount" result="Success" success="True" time="0.018"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithBoolOption__GetOption__ReturnOption" result="Success" success="True" time="0.002"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithEmptyOption__GetOption__ReturnEmptyString" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithEmptyOption__GetOption__ReturnNull" result="Success" success="True" time="0.000"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithInvalidOptionPrefix__GetOption__ReturnNull" result="Success" success="True" time="0.000"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithNoArguments__NewObject__NoOtherArguments" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="3" executed="True" name="ILRepack.Tests.CommandLineTests.WithOneOption__NewObject__ReturnOption" result="Success" success="True" time="0.007"/>
+                      <test-case asserts="5" executed="True" name="ILRepack.Tests.CommandLineTests.WithOptions__RemoveOption__ReturnAllOptionsExceptTheOneRemoved" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithOptions__RemoveOptions__ReturnMatchedOptions" result="Success" success="True" time="0.006"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithOptionWithInvalidAssignChar__GetOption__ReturnNull" result="Success" success="True" time="0.000"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithValidOption__GetOptionWithNameInCaps__ReturnOption" result="Success" success="True" time="0.000"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithValidOption__GetOtherOption__ReturnNull" result="Success" success="True" time="0.000"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithValidOptionPrefix__GetOption__ReturnNull" result="Success" success="True" time="0.000"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.CommandLineTests.WithZeroArguments__GetIsEmpty__ReturnTrue" result="Success" success="True" time="0.000"/>
+                    </results>
+                  </test-suite>
+                  <test-suite asserts="0" executed="True" name="RepackLoggerTests" result="Success" success="True" time="0.051" type="TestFixture">
+                    <results>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackLoggerTests.GivenAnEmptyOutputFile__OpenFile_CloseFile__OpenReturnsFalse_ClosedDoesNotThrowError" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackLoggerTests.GivenAnEmptyOutputFile__OpenFile_LogLine__OpenReturnsFalse_LogDoesNotThrowError" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackLoggerTests.GivenOutputFile__OpenFile_CloseFile_LogError__StreamIsOpened_StreamIsClosed_NoErrorIsThrown" result="Success" success="True" time="0.046"/>
+                    </results>
+                  </test-suite>
+                  <test-suite asserts="0" executed="True" name="RepackOptionsTests" result="Success" success="True" time="0.453" type="TestFixture">
+                    <results>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithAllowDuplicateResources__GetModifier__ReturnModifier" result="Success" success="True" time="0.311"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithAllowDuplicateTypes_WithNamespaces__CallParse__NamespacesAreSet" result="Success" success="True" time="0.007"/>
+                      <test-case asserts="2" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithAllowDuplicateTypes_WithNamespaces_WithTypes__CallParse__TypesAndNamespacesAreSet" result="Success" success="True" time="0.004"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithAllowDuplicateTypes_WithTypes__CallParse__DuplicateTypesAreSet" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithAllowMultipleAssign_WithNoCopyAttributes__Parse__ThrowsInvalidOperationException" result="Success" success="True" time="0.004"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithAttributeFile_WithCopyAttributes__Parse__ThrowsInvalidOperationException" result="Success" success="True" time="0.002"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithHelpModifierh__CallShouldShowUsage__ReturnTrue" result="Success" success="True" time="0.007"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithHelpModifierHelp__CallShouldShowUsage__ReturnTrue" result="Success" success="True" time="0.002"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithHelpModifierQuestionMark__CallShouldShowUsage__ReturnTrue" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="2" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithModifierNDebug__Parse__DebugInfoFalseIsSet" result="Success" success="True" time="0.001"/>
+                      <test-suite asserts="0" executed="True" name="WithModifierTargetVersion__Parse__TargetPlatformVersionIsSet" result="Success" success="True" time="0.012" type="ParameterizedTest">
+                        <results>
+                          <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithModifierTargetVersion__Parse__TargetPlatformVersionIsSet(&quot;v2&quot;)" result="Success" success="True" time="0.009"/>
+                          <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithModifierTargetVersion__Parse__TargetPlatformVersionIsSet(&quot;v4&quot;)" result="Success" success="True" time="0.001"/>
+                        </results>
+                      </test-suite>
+                      <test-case asserts="0" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithNoInputAssemblies__ParseProperties__ThrowException" result="Success" success="True" time="0.003"/>
+                      <test-case asserts="3" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithNoKeyFile__ParseProperties__ReadExcludeInternalizedMatches" result="Success" success="True" time="0.063"/>
+                      <test-case asserts="0" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithNoKeyFile__ParseProperties__ThrowException" result="Success" success="True" time="0.003"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithNoOptions_CallShouldShowUsage__ReturnTrue" result="Success" success="True" time="0.003"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionInternalize__Parse__ExcludeFileIsSet" result="Success" success="True" time="0.002"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionKeyFileNotSet_WithDelaySign__Parse__ThrowsInvalidOperationException" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionLog__Parse__LogFileIsSet" result="Success" success="True" time="0.002"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptions_CallShouldShowUsage__ReturnFalse" result="Success" success="True" time="0.000"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetKindEXE__Parse__TargetKindIsSet" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="0" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetKindInvalid__Parse__TargetKindIsSet" result="Success" success="True" time="0.002"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetKindLibrary__Parse__TargetKindIsSet" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetKindWinEXE__Parse__TargetKindIsSet" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="2" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetPlatform__Parse__DirectoryAndVersionAreSet" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionTargetPlatform__Parse__VersionIsSet" result="Success" success="True" time="0.001"/>
+                      <test-case asserts="1" executed="True" name="ILRepack.Tests.RepackOptionsTests.WithOptionVersion__Parse__VersionIsSet" result="Success" success="True" time="0.001"/>
+                    </results>
+                  </test-suite>
+                  <test-suite asserts="0" executed="True" name="Steps" result="Success" success="True" time="0.508" type="Namespace">
+                    <results>
+                      <test-suite asserts="0" executed="True" name="ResourceProcessing" result="Success" success="True" time="0.495" type="Namespace">
+                        <results>
+                          <test-suite asserts="0" executed="True" name="BamlGeneratorTests" result="Success" success="True" time="0.495" type="TestFixture">
+                            <results>
+                              <test-suite asserts="0" executed="True" name="AddMergedDictionaries_GivenExistingGenericXaml_CreatesExpectedXaml" result="Success" success="True" time="0.472" type="ParameterizedTest">
+                                <results>
+                                  <test-case asserts="2" executed="True" name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.AddMergedDictionaries_GivenExistingGenericXaml_CreatesExpectedXaml(&quot;EmptyResourceDictionary/Start.xaml&quot;,&quot;EmptyResourceDictionary/End.xaml&quot;)" result="Success" success="True" time="0.442"/>
+                                  <test-case asserts="2" executed="True" name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.AddMergedDictionaries_GivenExistingGenericXaml_CreatesExpectedXaml(&quot;NonExistingMergedDictionaries/Start.xaml&quot;,&quot;NonExistingMergedDictionaries/End.xaml&quot;)" result="Success" success="True" time="0.013"/>
+                                  <test-case asserts="2" executed="True" name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.AddMergedDictionaries_GivenExistingGenericXaml_CreatesExpectedXaml(&quot;ExistingMergedDictionaries/Start.xaml&quot;,&quot;ExistingMergedDictionaries/End.xaml&quot;)" result="Success" success="True" time="0.016"/>
+                                </results>
+                              </test-suite>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.AddMergedDictionaries_GivenExistingGenericXamlThatIsNotAResourceDictionary_LogsErrorAndReturnsSameBaml" result="Success" success="True" time="0.011"/>
+                              <test-case asserts="2" executed="True" name="ILRepack.Tests.Steps.ResourceProcessing.BamlGeneratorTests.GenerateThemesGenericXaml_GivenIncludedXamlFiles_GeneratesSameBamlAsSample" result="Success" success="True" time="0.009"/>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite asserts="0" executed="True" name="XamlResourcePathPatcherStepTests" result="Success" success="True" time="0.012" type="TestFixture">
+                        <results>
+                          <test-suite asserts="0" executed="True" name="PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath" result="Success" success="True" time="0.007" type="ParameterizedTest">
+                            <results>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;pack://application:,,,/ClassLibrary;component/TextBlockStyles.xaml&quot;,&quot;pack://application:,,,/MainAssembly;component/ClassLibrary/TextBlockStyles.xaml&quot;)" result="Success" success="True" time="0.002"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/MainAssembly;component/ButtonStyles.xaml&quot;,&quot;/MainAssembly;component/ButtonStyles.xaml&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/ClassLibrary;component/ButtonStyles.xaml&quot;,&quot;/MainAssembly;component/ClassLibrary/ButtonStyles.xaml&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/themes/ButtonStyles.xaml&quot;,&quot;/themes/ButtonStyles.xaml&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(null,null)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;&quot;,&quot;&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;asdasd&quot;,&quot;asdasd&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/lol&quot;,&quot;/lol&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;123&quot;,&quot;123&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInMainAssembly_ReturnsExpectedPatchedPath(&quot;/ClassLibrary&quot;,&quot;/ClassLibrary&quot;)" result="Success" success="True" time="0.000"/>
+                            </results>
+                          </test-suite>
+                          <test-suite asserts="0" executed="True" name="PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath" result="Success" success="True" time="0.004" type="ParameterizedTest">
+                            <results>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;pack://application:,,,/ClassLibrary;component/TextBlockStyles.xaml&quot;,&quot;pack://application:,,,/MainAssembly;component/ClassLibrary/TextBlockStyles.xaml&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;/ClassLibrary;component/ButtonStyles.xaml&quot;,&quot;/MainAssembly;component/ClassLibrary/ButtonStyles.xaml&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;/themes/ButtonStyles.xaml&quot;,&quot;/ClassLibrary/themes/ButtonStyles.xaml&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(null,null)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;&quot;,&quot;&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;asdasd&quot;,&quot;asdasd&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;/lol&quot;,&quot;/lol&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;123&quot;,&quot;123&quot;)" result="Success" success="True" time="0.000"/>
+                              <test-case asserts="1" executed="True" name="ILRepack.Tests.Steps.XamlResourcePathPatcherStepTests.PatchPath_GivenPathInReferencedAssembly_ReturnsExpectedPatchedPath(&quot;/ClassLibrary&quot;,&quot;/ClassLibrary&quot;)" result="Success" success="True" time="0.000"/>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>


### PR DESCRIPTION
This continues Sorin's work to merge the parallel test results.

Also, took the liberty to create the `nuget-base` plugin so we can avoid creating (useless) nunit tasks if we don't want.
