### PR TITLE
Default working dir for NUnit v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # gradle-nunit-plugin changelog
 
 ## 1.6
+### Changed
 * Default working directory of NUnit v3 to build\nunit\
 
 ## 1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # gradle-nunit-plugin changelog
 
 ## 1.6
+* Default working directory of NUnit v3 to build\nunit\
 
 ## 1.5
 ### Fixed

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -266,6 +266,9 @@ class NUnit extends ConventionTask {
         } else {
             commandLineArgs += "-xml:$testReportPath"
         }
+        if (isV3) {
+            commandLineArgs += "-work:$outputFolder"
+        }
 
         getTestAssemblies().each {
             def file = project.file(it)


### PR DESCRIPTION
To avoid creating InternalTrace.{0}.log under the current directory by default
