### PR TITLE
Refactor NUnit v3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # gradle-nunit-plugin changelog
 
 ## 1.6
+### Added
+* `getCommandArgs` is added to NUnit task
+
 ### Changed
 * Default working directory of NUnit v3 to build\nunit\
 * Renamed parallel_forks to parallelForks in NUnit task
+* Refactored for NUnit3 support and log a warnings if deprecated parameters `run` or `runList` has been specified
 
 ## 1.5
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # gradle-nunit-plugin changelog
 
 ## 1.6
+### Changed
+* Default working directory of NUnit v3 to build\nunit\
+* Renamed parallel_forks to parallelForks in NUnit task
 
 ## 1.5
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It creates a task 'nunit' that may be configured as follows:
 
     nunit {
         // optional - defaults to '2.6.4', but plugin is compatible with v3+ as well
+        // it must be the *first* parameter if specified
         nunitVersion
         // optional - defaults to 'https://github.com/nunit/nunitv2/releases/download'
         nunitDownloadUrl

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It creates a task 'nunit' that may be configured as follows:
 
     nunit {
         // optional - defaults to '2.6.4', but plugin is compatible with v3+ as well
-        // it must be the *first* parameter if specified
+        // for compatibility reason, nunitVersion should be set (if needed) before applying version specific parameters
         nunitVersion
         // optional - defaults to 'https://github.com/nunit/nunitv2/releases/download'
         nunitDownloadUrl

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -1,9 +1,9 @@
 package com.ullink.gradle.nunit
 
 import org.bouncycastle.math.raw.Nat
-import org.gradle.api.GradleException
 import org.gradle.api.internal.ConventionTask
 import groovyx.gpars.GParsPool
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
@@ -15,29 +15,18 @@ class NUnit extends ConventionTask {
     def nunitVersion
     def nunitDownloadUrl
     List testAssemblies
-    def include
-    def exclude
-    def where
+
     def framework
     def verbosity
     def config
     def timeout
-
-    // TODO: shouldn't we just make it a single variable and detect which case it is when invoking NUnit instead?
-    // runList and run are mutually exclusive
-    def runList
-    def run
-
-    // testList and test are mutually exclusive, NUnit3-specific
-    def testList
-    def test
 
     def reportFolder
     boolean useX86 = false
     boolean shadowCopy = false
     String reportFileName = 'TestResult.xml'
     boolean ignoreFailures = false
-    boolean parallel_forks = true
+    boolean parallelForks = true
 
     NUnit() {
         conventionMapping.map "reportFolder", { new File(outputFolder, 'reports') }
@@ -46,21 +35,20 @@ class NUnit extends ConventionTask {
         }
     }
 
-    File nunitBinFile(String file) {
-        new File(project.file(getNunitHome()), "bin/${file}")
-    }
-
     boolean getIsV3() {
-        getNunitVersion().startsWith("3.")
+        getNunitVersion().startsWith('3.')
     }
 
-    File getNunitExec() {
+    void setNunitVersion(def version) {
+        this.nunitVersion = version
+        if (version.startsWith('3.')) {
+            this.metaClass.mixin NUnit3Mixins
+        }
+    }
+
+    File nunitBinFile(String file) {
         assert getNunitHome(), "You must install NUnit and set nunit.home property or NUNIT_HOME env variable"
-        File nunitExec = isV3
-            ? nunitBinFile('nunit3-console.exe')
-            : nunitBinFile("nunit-console${useX86 ? '-x86' : ''}.exe")
-        assert nunitExec.isFile(), "You must install NUnit and set nunit.home property or NUNIT_HOME env variable"
-        return nunitExec
+        new File(project.file(getNunitHome()), "bin/${file}")
     }
 
     File getOutputFolder() {
@@ -74,6 +62,7 @@ class NUnit extends ConventionTask {
     @OutputFile
     File getTestReportPath() {
         // for the non-default nunit tasks, ensure we write the report in a separate file
+        // TODO: Do we need to supply prefix when user has specified its own report file name?
         def reportFileNamePrefix = name == 'nunit' ? '' : name
         new File(getReportFolderImpl(), reportFileNamePrefix + reportFileName)
     }
@@ -84,14 +73,9 @@ class NUnit extends ConventionTask {
     }
 
     def decideExecutionPath(Closure singleRunAction, Closure multipleRunsAction) {
-        if (!test && run) {
-            test = run
-        }
-
-        if (!parallel_forks || !test) {
+        if (!parallelForks || !test) {
             return singleRunAction(test)
-        }
-        else {
+        } else {
             return multipleRunsAction(test)
         }
     }
@@ -150,7 +134,7 @@ class NUnit extends ConventionTask {
     }
 
     def testRun(def test, def reportPath) {
-        def cmdLine = [nunitExec.absolutePath, *buildCommandArgs(test, reportPath)]
+        def cmdLine = [getNunitExec().absolutePath, *buildCommandArgs(test, reportPath)]
         if (!isFamily(FAMILY_WINDOWS)) {
             cmdLine = ["mono", *cmdLine]
         }
@@ -178,7 +162,7 @@ class NUnit extends ConventionTask {
             return
         }
 
-        throw new GradleException("${nunitExec} execution failed (ret=${mbr.exitValue})");
+        throw new GradleException("${getNunitExec()} execution failed (ret=${mbr.exitValue})");
     }
 
     def prepareExecute() {
@@ -194,82 +178,30 @@ class NUnit extends ConventionTask {
                 verb = 'Verbose'
             } else if (logger.infoEnabled) {
                 verb = 'Info'
-            } else { // 'quiet'
+            } else {
+                // 'quiet'
                 verb = 'Warning'
             }
         }
         if (verb) {
             commandLineArgs += "-trace=$verb"
         }
-        if (isV3) {
-            if (useX86) {
-                commandLineArgs += '-x86'
-            }
-        }
-        if (isV3) {
-            if (include || exclude) {
-                throw new GradleException("'include'/'exclude' options aren't supported on NUnit v3, use 'where' option instead")
-            }
-            if (where) {
-                commandLineArgs += "-where:$where"
-            }
-        } else {
-            if (where) {
-                throw new GradleException("'where' isn't supported on NUnit v2, you need to set the NUnit version to v3+")
-            }
-            if (exclude) {
-                commandLineArgs += "-exclude:$exclude"
-            }
-            if (include) {
-                commandLineArgs += "-include:$include"
-            }
-        }
         if (framework) {
             commandLineArgs += "-framework:$framework"
         }
-        if (isV3) {
-            if (shadowCopy) {
-                commandLineArgs += '-shadowcopy'
-            }
-        } else {
-            if (!shadowCopy) {
-                commandLineArgs += '-noshadow'
-            }
-        }
-        // Maintain backward compatibility with old (nunit 2.x) gradle files.
-        if (!testList && runList) {
-            testList = runList
-        }
-
-        if (testList) {
-            if (isV3) {
-                commandLineArgs += "-testlist:$testList"
-            } else {
-                commandLineArgs += "-runList:$testList"
-            }
-        }
-        if (test) {
-            if (isV3) {
-                commandLineArgs += "-test:$test"
-            } else {
-                commandLineArgs += "-run:$test"
-            }
-        }
-        if (config){
+        if (config) {
             commandLineArgs += "-config:$config"
         }
-        if (timeout){
+        if (timeout) {
             commandLineArgs += "-timeout:$timeout"
         }
-        if (isV3) {
-            commandLineArgs += "-result:$testReportPath"
-        } else {
-            commandLineArgs += "-xml:$testReportPath"
-        }
+        commandLineArgs += "-work:$outputFolder"
+
+        commandLineArgs += buildAdditionalCommandArgs(test, testReportPath)
 
         getTestAssemblies().each {
             def file = project.file(it)
-            if (file.exists() )
+            if (file.exists())
                 commandLineArgs += file
             else
                 commandLineArgs += it

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit2Mixins.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit2Mixins.groovy
@@ -1,0 +1,45 @@
+package com.ullink.gradle.nunit
+
+class NUnit2Mixins {
+
+    def run
+    def runList
+    def include
+    def exclude
+
+    def useX86
+    def shadowCopy
+
+    File getNunitExec() {
+        File nunitExec = this.nunitBinFile("nunit-console${useX86 ? '-x86' : ''}.exe")
+        assert nunitExec.isFile(), "You must install NUnit and set nunit.home property or NUNIT_HOME env variable"
+        return nunitExec
+    }
+
+    def getTest() {
+        run
+    }
+
+    def buildAdditionalCommandArgs(def test, def testReportPath) {
+        def commandLineArgs = []
+
+        if (exclude) {
+            commandLineArgs += "-exclude:$exclude"
+        }
+        if (include) {
+            commandLineArgs += "-include:$include"
+        }
+        if (!shadowCopy) {
+            commandLineArgs += '-noshadow'
+        }
+        if (runList) {
+            commandLineArgs += "-runList:$runList"
+        }
+        if (run) {
+            commandLineArgs += "-run:$run"
+        }
+        commandLineArgs += "-xml:$testReportPath"
+
+        commandLineArgs
+    }
+}

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit2Mixins.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit2Mixins.groovy
@@ -7,20 +7,23 @@ class NUnit2Mixins {
     def include
     def exclude
 
-    def useX86
-    def shadowCopy
+    void setRun(def run) {
+        this.run = run
+        this.setTest(run)
+    }
+
+    void setRunList(def runList) {
+        this.runList = runList
+        this.setTestList(runList)
+    }
 
     File getNunitExec() {
-        File nunitExec = this.nunitBinFile("nunit-console${useX86 ? '-x86' : ''}.exe")
+        File nunitExec = this.nunitBinFile("nunit-console${this.useX86 ? '-x86' : ''}.exe")
         assert nunitExec.isFile(), "You must install NUnit and set nunit.home property or NUNIT_HOME env variable"
         return nunitExec
     }
 
-    def getTest() {
-        run
-    }
-
-    def buildAdditionalCommandArgs(def test, def testReportPath) {
+    def buildAdditionalCommandArgs(def testNames, def testReportPath) {
         def commandLineArgs = []
 
         if (exclude) {
@@ -29,14 +32,14 @@ class NUnit2Mixins {
         if (include) {
             commandLineArgs += "-include:$include"
         }
-        if (!shadowCopy) {
+        if (!this.shadowCopy) {
             commandLineArgs += '-noshadow'
         }
         if (runList) {
             commandLineArgs += "-runList:$runList"
         }
-        if (run) {
-            commandLineArgs += "-run:$run"
+        if (testNames) {
+            commandLineArgs += "-run:$testNames"
         }
         commandLineArgs += "-xml:$testReportPath"
 

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit3Mixins.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit3Mixins.groovy
@@ -1,0 +1,73 @@
+package com.ullink.gradle.nunit
+
+import org.gradle.api.GradleException
+
+class NUnit3Mixins {
+
+    def where
+    def test
+    def testList
+
+    def useX86
+    def shadowCopy
+
+    def methodMissing(String name, args) {
+        def obsoleteParameters = [
+            run: 'test',
+            runList: 'testList',
+            include: 'where',
+            exclude: 'where'
+        ]
+        methodMissing(obsoleteParameters, name, args)
+    }
+
+    static void methodMissing(def obsoleteParameterMap, String name, args) {
+        if (name.startsWith('set')) {
+
+            // variables missing in NUnit 3
+            def variableName = name.substring(3, 1).toLowerCase()
+            if (name.length > 3) {
+                 variableName += name.substring(4)
+            }
+
+            // Obsolete variables
+            if (obsoleteParameterMap[variableName]) {
+                throwOnObsoleteParameter variableName obsoleteParameterMap[variableName]
+            }
+        }
+        throw new MissingMethodException(name, NUnit3Mixins.class, args)
+    }
+
+    static void throwOnObsoleteParameter(def oldName, def newName) {
+        throw new GradleException("'$oldName' option isn't supported, use '$newName' option instead")
+    }
+
+    File getNunitExec() {
+        File nunitExec = this.nunitBinFile('nunit3-console.exe')
+        assert nunitExec.isFile(), "You must install NUnit and set nunit.home property or NUNIT_HOME env variable"
+        return nunitExec
+    }
+
+    def buildAdditionalCommandArgs(def test, def testReportPath) {
+        def commandLineArgs = []
+
+        if (useX86) {
+            commandLineArgs += '-x86'
+        }
+        if (where) {
+            commandLineArgs += "-where:$where"
+        }
+        if (shadowCopy) {
+            commandLineArgs += '-shadowcopy'
+        }
+        if (testList) {
+            commandLineArgs += "-testlist:$testList"
+        }
+        if (test) {
+            commandLineArgs += "-test:$test"
+        }
+        commandLineArgs += "-result:$testReportPath"
+
+        commandLineArgs
+    }
+}

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit3Mixins.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit3Mixins.groovy
@@ -5,41 +5,35 @@ import org.gradle.api.GradleException
 class NUnit3Mixins {
 
     def where
-    def test
-    def testList
 
-    def useX86
-    def shadowCopy
-
-    def methodMissing(String name, args) {
-        def obsoleteParameters = [
-            run: 'test',
-            runList: 'testList',
-            include: 'where',
-            exclude: 'where'
-        ]
-        methodMissing(obsoleteParameters, name, args)
+    // Deprecated
+    void setRun(def run) {
+        logDeprecatedParameters('run', 'test')
+        this.setTest(run)
     }
 
-    static void methodMissing(def obsoleteParameterMap, String name, args) {
-        if (name.startsWith('set')) {
-
-            // variables missing in NUnit 3
-            def variableName = name.substring(3, 1).toLowerCase()
-            if (name.length > 3) {
-                 variableName += name.substring(4)
-            }
-
-            // Obsolete variables
-            if (obsoleteParameterMap[variableName]) {
-                throwOnObsoleteParameter variableName obsoleteParameterMap[variableName]
-            }
-        }
-        throw new MissingMethodException(name, NUnit3Mixins.class, args)
+    // Deprecated
+    void setRunList(def runList) {
+        logDeprecatedParameters('runList', 'testList')
+        this.setTestList(runList)
     }
 
-    static void throwOnObsoleteParameter(def oldName, def newName) {
-        throw new GradleException("'$oldName' option isn't supported, use '$newName' option instead")
+    void logDeprecatedParameters(def variableName, def newVariableName) {
+        this.getLogger().warn("'$variableName' option has been deprecated, please use '$newVariableName' option instead")
+    }
+
+    // Obsolete
+    void setInclude(def obj) {
+        throwOnObsoleteParameters('include', 'where')
+    }
+
+    // Obsolete
+    void setExclude(def obj) {
+        throwOnObsoleteParameters('exclude', 'where')
+    }
+
+    void throwOnObsoleteParameters(def variableName, def newVariableName) {
+        throw new GradleException("'$variableName' option isn't supported, please use '$newVariableName' option instead")
     }
 
     File getNunitExec() {
@@ -51,20 +45,20 @@ class NUnit3Mixins {
     def buildAdditionalCommandArgs(def test, def testReportPath) {
         def commandLineArgs = []
 
-        if (useX86) {
+        if (this.useX86) {
             commandLineArgs += '-x86'
         }
         if (where) {
             commandLineArgs += "-where:$where"
         }
-        if (shadowCopy) {
+        if (this.shadowCopy) {
             commandLineArgs += '-shadowcopy'
         }
-        if (testList) {
-            commandLineArgs += "-testlist:$testList"
+        if (this.testList) {
+            commandLineArgs += "-testlist:${this.testList}"
         }
         if (test) {
-            commandLineArgs += "-test:$test"
+            commandLineArgs += "-test:${test}"
         }
         commandLineArgs += "-result:$testReportPath"
 

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
@@ -7,6 +7,7 @@ class NUnitBasePlugin implements Plugin<Project> {
         project.apply plugin: 'de.undercouch.download'
         project.tasks.withType(NUnit).whenTaskAdded { NUnit task ->
             applyNunitConventions(task, project)
+            task.metaClass.mixin NUnit2Mixins
         }
     }
 

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -42,7 +42,7 @@ public class NUnitTest {
     public void whenSingleTest_notParallel_singleTestReport(){
         def nunit = getNUnitTask()
         nunit.reportFileName = 'TestResult.xml'
-        nunit.parallel_forks = true
+        nunit.parallelForks = true
         nunit.run = 'Test1'
         nunit.reportFolder = './'
 
@@ -53,7 +53,7 @@ public class NUnitTest {
     public void whenSingleTest_Parallel_singleTestReport(){
         def nunit = getNUnitTask()
         nunit.reportFileName = 'TestResult.xml'
-        nunit.parallel_forks = true
+        nunit.parallelForks = true
         nunit.run = 'Test1'
         nunit.reportFolder = './'
 
@@ -64,7 +64,7 @@ public class NUnitTest {
     public void whenMultipleTests_notParallel_singleTestReport(){
         def nunit = getNUnitTask()
         nunit.reportFileName = 'TestResult.xml'
-        nunit.parallel_forks = false
+        nunit.parallelForks = false
         nunit.run = ['Test1', 'Test2']
         nunit.reportFolder = './'
 
@@ -75,7 +75,7 @@ public class NUnitTest {
     public void whenMultipleTests_parallel_singleTestReport(){
         def nunit = getNUnitTask()
         nunit.reportFileName = 'TestResult.xml'
-        nunit.parallel_forks = true
+        nunit.parallelForks = true
         nunit.run = ['Test1', 'Test2']
         nunit.reportFolder = './'
 

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -1,5 +1,8 @@
 package com.ullink
 
+import static groovy.test.GroovyAssert.shouldFail
+
+import org.gradle.api.GradleException
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
 
@@ -50,7 +53,7 @@ public class NUnitTest {
     }
 
     @Test
-    public void whenSingleTest_Parallel_singleTestReport(){
+    public void whenSingleTest_parallel_singleTestReport(){
         def nunit = getNUnitTask()
         nunit.reportFileName = 'TestResult.xml'
         nunit.parallelForks = true
@@ -80,6 +83,94 @@ public class NUnitTest {
         nunit.reportFolder = './'
 
         assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
+    }
+
+    @Test
+    public void whenNUnit2_run_runSpecified() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '2.0.0'
+        nunit.run = ['Test1', 'Test2']
+
+        def commandArgs = nunit.getCommandArgs()
+
+        // list contains does not work with GString
+        assert commandArgs.find { it == '-run:Test1,Test2' }
+    }
+
+    @Test
+    public void whenNUnit2_test_runSpecified() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '2.0.0'
+        nunit.test = ['Test1', 'Test2']
+
+        def commandArgs = nunit.getCommandArgs()
+
+        assert commandArgs.find { it == '-run:Test1,Test2' }
+    }
+
+    @Test
+    public void whenNUnit3_test_testSpecified() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '3.0.0'
+        nunit.test = ['Test1', 'Test2']
+
+        def commandArgs = nunit.getCommandArgs()
+
+        assert commandArgs.find { it == '-test:Test1,Test2' }
+    }
+
+    @Test
+    public void whenNUnit3_run_testSpecified() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '3.0.0'
+        nunit.run = ['Test1', 'Test2']
+
+        def commandArgs = nunit.getCommandArgs()
+
+        assert commandArgs.find { it == '-test:Test1,Test2' }
+    }
+
+    @Test
+    public void whenNUnit2_include_shouldPass() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '2.0.0'
+        nunit.include = 'foo'
+
+        def commandArgs = nunit.getCommandArgs()
+
+        assert commandArgs.find { it == '-include:foo' }
+    }
+
+    @Test
+    public void whenNUnit3_include_shouldFail() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '3.0.0'
+
+        shouldFail(GradleException) {
+            nunit.include = 'foo'
+        }
+    }
+
+    @Test
+    public void whenNUnit3_shadowcopy_shadowcopy() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '3.0.0'
+        nunit.shadowCopy = true
+
+        def commandArgs = nunit.getCommandArgs()
+
+        assert commandArgs.find { it == '-shadowcopy' }
+    }
+
+    @Test
+    public void whenNUnit2_notShadowcopy_noshadow() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '2.0.0'
+        nunit.shadowCopy = false
+
+        def commandArgs = nunit.getCommandArgs()
+
+        assert commandArgs.find { it == '-noshadow' }
     }
 
     def getNUnitTask() {


### PR DESCRIPTION
- Changed the nunit version specific implementation into mixins
- Added getCommandArgs to support gradle-opencover-plugin
- Renamed parallel_forks to parallelForks to follow the same naming
- Default working directory of NUnit v3 to build\nunit\
