### PR TITLE
Support parallelization using multiple 'where' clauses for NUnit v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # gradle-nunit-plugin changelog
 ## 1.9
+### Added
 * 'labels' attribute is added to NUnit
+* Added support for multiple 'where' clauses for NUnit v3, redirected 'test' to 'where'
 
 ## 1.8
 ### Fixed

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit2Mixins.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit2Mixins.groovy
@@ -17,10 +17,26 @@ class NUnit2Mixins {
         this.setTestList(runList)
     }
 
+    void setTestInternal(def testWrapper, def whereWrapper, def target) {
+        testWrapper.value = target
+    }
+
     File getNunitExec() {
         File nunitExec = this.nunitBinFile("nunit-console${this.useX86 ? '-x86' : ''}.exe")
         assert nunitExec.isFile(), "You must install NUnit and set nunit.home property or NUNIT_HOME env variable"
         return nunitExec
+    }
+
+    def getRunActionInput() {
+        return test.value
+    }
+
+    def combine(def input) {
+        return input.join(',')
+    }
+
+    def toFileName(input) {
+        return input
     }
 
     def buildAdditionalCommandArgs(def testNames, def testReportPath) {

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitTestResultsMerger.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitTestResultsMerger.groovy
@@ -10,15 +10,16 @@ class NUnitTestResultsMerger {
     }
 
     String merge(List<String> stringTestResults) {
-        def testResults = stringTestResults.collect { new XmlParser().parseText(it) }
-        def firstTestResult = testResults.first()
-        def baseXml = new XmlParser().parseText(
-                '<test-results name="Merged results">' +
+        String xmlShell = '<test-results name="Merged results">' +
                 '   <test-suite type="Test Project" executed="True" name="" asserts="0">' +
                 '       <results/>' +
                 '  </test-suite>' +
                 '</test-results>'
-        )
+
+        def testResults = stringTestResults.collect { new XmlParser().parseText(it) }
+        def firstTestResult = testResults.first()
+
+        def baseXml = new XmlParser().parseText(xmlShell)
 
         baseXml.children().add(0, firstTestResult.environment.first())
         baseXml.children().add(1, firstTestResult.'culture-info'.first())

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -30,11 +30,25 @@ public class NUnitTest {
     }
 
     @Test
-    public void getTestInputsAsString_works() {
+    public void whenNUnit2_getTestInputsAsString_works() {
         def nunit = getNUnitTask()
+        nunit.nunitVersion = '2.0.0'
         assert nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
         assert nunit.getTestInputsAsString('A') == 'A'
         assert nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A,B,C'
+        assert nunit.getTestInputsAsString(['A']) == 'A'
+        assert nunit.getTestInputsAsString('') == ''
+        assert nunit.getTestInputsAsString([]) == ''
+        assert nunit.getTestInputsAsString(null) == ''
+    }
+
+    @Test
+    public void whenNUnit3_getTestInputsAsString_works() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '3.0.0'
+        assert nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
+        assert nunit.getTestInputsAsString('A') == 'A'
+        assert nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A or B or C'
         assert nunit.getTestInputsAsString(['A']) == 'A'
         assert nunit.getTestInputsAsString('') == ''
         assert nunit.getTestInputsAsString([]) == ''
@@ -109,25 +123,36 @@ public class NUnitTest {
     }
 
     @Test
-    public void whenNUnit3_test_testSpecified() {
+    public void whenNUnit3_where_whereSpecified() {
+        def nunit = getNUnitTask()
+        nunit.nunitVersion = '3.0.0'
+        nunit.where = [ 'test == \'Test1\'', 'test == \'Test2\'']
+
+        def commandArgs = nunit.getCommandArgs()
+
+        assert commandArgs.find { it == '-where:test == \'Test1\' or test == \'Test2\'' }
+    }
+
+    @Test
+    public void whenNUnit3_test_whereSpecified() {
         def nunit = getNUnitTask()
         nunit.nunitVersion = '3.0.0'
         nunit.test = ['Test1', 'Test2']
 
         def commandArgs = nunit.getCommandArgs()
 
-        assert commandArgs.find { it == '-test:Test1,Test2' }
+        assert commandArgs.find { it == '-where:test == \'Test1\' or test == \'Test2\'' }
     }
 
     @Test
-    public void whenNUnit3_run_testSpecified() {
+    public void whenNUnit3_run_whereSpecified() {
         def nunit = getNUnitTask()
         nunit.nunitVersion = '3.0.0'
         nunit.run = ['Test1', 'Test2']
 
         def commandArgs = nunit.getCommandArgs()
 
-        assert commandArgs.find { it == '-test:Test1,Test2' }
+        assert commandArgs.find {it == '-where:test == \'Test1\' or test == \'Test2\'' }
     }
 
     @Test


### PR DESCRIPTION
- Redirect 'test' to 'where' by translating to TSL
- If parallelization is enabled and a list of where clauses is present
  then use it to filter each of the parallel runs.
- If both 'run'/'test' and 'where' are used in the args, then the
  last one to be encountered will determine the value

Change-Id: If06047f6862ce5a219482b0d4be40fc38d366de6
