### PR TITLE
Update the plugin to allow a configurable start

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,18 @@ It creates a task 'nunit' that may be configured as follows:
         include = 'BaseLine'
         // for NUnit v3+, use _where_ option instead of include/exclude
         framework = 'net-1.1'
-        shadowCopy = true        
+        shadowCopy = true
         // redirect output to file
         logFile = 'TestOutput.log'
 
         // for NUnit v3+
         resultFormat = 'nunit2'
-        
+
         // environment variables map (already defined)
         env = [:]
+
+        // optional - if set, can overwrite the default command arguments in order to allow running of external tools like dotMemoryUnit
+        nunitCommandModifier = { nunitBin, args -> [nunitBin, *args] }
     }
 
 # License

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -41,6 +41,9 @@ class NUnit extends ConventionTask {
     def test = Wrapper.newInstance()
     def where = Wrapper.newInstance()
     def testList
+    def nunitCommandModifier = { nunitBin, args ->
+        [nunitBin, *args]
+    }
 
     Map<String, Object> env = [:]
 
@@ -259,8 +262,12 @@ class NUnit extends ConventionTask {
         return combine(testInput)
     }
 
+    def getCommandLine(input, reportPath){
+        return nunitCommandModifier(getNunitExec().absolutePath, buildCommandArgs(input, reportPath))
+    }
+
     def run(def input, def reportPath) {
-        def cmdLine = [getNunitExec().absolutePath, *buildCommandArgs(input, reportPath)]
+        def cmdLine = getCommandLine(input, reportPath)
         if (!isFamily(FAMILY_WINDOWS)) {
             cmdLine = ["mono", *cmdLine]
         }

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -221,6 +221,34 @@ public class NUnitTest {
         assert commandArgs.find { it =~ /-result:.*TestResult\.xml;format=nunit3/ }
     }
 
+    @Test
+    public void whenRun_withDefaultCommandModifier_setsPathAndBuildArgs()
+    {
+        def nunit = getNUnitTask()
+
+        def cmdLine = nunit.getCommandLine('input', 'path')
+
+        assert cmdLine == [nunit.getNunitExec().absolutePath, *nunit.buildCommandArgs('input', 'path')]
+    }
+
+    @Test
+    public void whenRun_withCustomCommandModifier_setsPathAndBuildArgsWithCustomArguments() {
+        def nunit = getNUnitTask()
+
+        nunit.nunitCommandModifier = { path, args ->
+            ['dotMemoryUnit.exe', path, 'custom-args', *args]
+        }
+
+        def cmdLine = nunit.getCommandLine('input', 'path')
+
+        assert cmdLine == [
+                'dotMemoryUnit.exe',
+                nunit.getNunitExec().absolutePath,
+                'custom-args',
+                *nunit.buildCommandArgs('input', 'path')
+        ]
+    }
+
     def getNUnitTask() {
         def project = ProjectBuilder.builder().build()
         project.apply plugin: 'nunit'


### PR DESCRIPTION
Adds nunitCommandModifier config which if set, can overwrite
the default command arguments in order to allow running of
external tools like dotMemoryUnit.