### PR TITLE
Fix download for v. 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/
 /*.iml
 build/
+out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Changed
 * increase default NUnit runner version from 2.6.4 to 3.9.0
 * built with gradle 4.10.2
+* take as test assemblies only those containing "test.dll" or "tests.dll"
+to not require explicit config for projects like "test-framework.dll"
 
 ### Fixed
 * Upgrade `gradle-download-task` to 3.4.4 to fix 'Invalid cookie expiry' on download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # gradle-nunit-plugin changelog
+##1.13
+### Changed
+* increase default NUnit runner version from 2.6.4 to 3.9.0
+* built with gradle 4.10.2
+
+### Fixed
+* Upgrade `gradle-download-task` to 3.4.4 to fix 'Invalid cookie expiry' on download
+* Allow download of NUnit 3.9 runner
+
 ## 1.12
 ### Changed
 * upgrade gradle-download-plugin to 3.2
 * upgrade net.researchgate.release to 2.6.0
 * built with gradle 4.2.1
 
-## Fixed
+### Fixed
 * Apply default parameters on plugin `com.ullink.msbuild` instead of `msbuild`
 which is required starting from `gradle-msbuild-plugin` 2.17
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Or, when using Gradle lower than 2.1:
 It creates a task 'nunit' that may be configured as follows:
 
     nunit {
-        // optional - defaults to '2.6.4', but plugin is compatible with v3+ as well
+        // optional - defaults to '3.9.0', but plugin is compatible with v3+ as well
         // for compatibility reason, nunitVersion should be set (if needed) before applying version specific parameters
         nunitVersion
-        // optional - defaults to 'https://github.com/nunit/nunitv2/releases/download'
+        // optional - defaults to 'https://github.com/nunit/nunit-console/releases/download'
         nunitDownloadUrl
         // optional - defaults to NUNIT_HOME env variable if set or to a downloaded version of NUnit fitting the
         // specified nunitVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ group = 'com.ullink.gradle'
 description 'gradle-nunit-plugin is a Gradle plugin that enables NUnit testing'
 
 dependencies {
-    compile 'de.undercouch:gradle-download-task:3.3.0'
+    compile 'de.undercouch:gradle-download-task:3.4.3'
     compile 'org.codehaus.gpars:gpars:1.2.1'
     testCompile 'xmlunit:xmlunit:1.6'
     testCompile 'junit:junit:4.11'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -71,6 +71,11 @@ class NUnit extends ConventionTask {
         major == 3 && minor >= 5
     }
 
+    boolean getIsV39() {
+        def (major, minor, patch) = getNunitVersion().tokenize('.')*.toInteger()
+        major == 3 && minor == 9
+    }
+
     String getGitHubRepoName() {
         if (isV35OrAbove) {
             return 'nunit-console'
@@ -85,6 +90,9 @@ class NUnit extends ConventionTask {
         this.nunitVersion = version
         if (getIsV3(version)) {
             this.metaClass.mixin NUnit3Mixins
+        }
+        else {
+            this.metaClass.mixin NUnit2Mixins
         }
     }
 
@@ -134,9 +142,12 @@ class NUnit extends ConventionTask {
     }
 
     String getFixedDownloadVersion() {
-        def version = getNunitVersion()
+        String version = getNunitVersion()
         if (isV35OrAbove && version.endsWith('.0')) {
-            return version.take(version.length() - 2)
+            version = version.take(version.length() - 2)
+            if (isV39) {
+                version = "v${version}"
+            }
         }
 
         version

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
@@ -7,13 +7,13 @@ class NUnitBasePlugin implements Plugin<Project> {
         project.apply plugin: 'de.undercouch.download'
         project.tasks.withType(NUnit).whenTaskAdded { NUnit task ->
             applyNunitConventions(task, project)
-            task.metaClass.mixin NUnit2Mixins
+            task.metaClass.mixin NUnit3Mixins
         }
     }
 
     def applyNunitConventions(NUnit task, Project project) {
         task.conventionMapping.map "nunitDownloadUrl", { "https://github.com/nunit/${task.gitHubRepoName}/releases/download" }
-        task.conventionMapping.map "nunitVersion", { '2.6.4' }
+        task.conventionMapping.map "nunitVersion", { '3.9.0' }
         task.conventionMapping.map "nunitHome", {
             if (System.getenv()['NUNIT_HOME']) {
                 return System.getenv()['NUNIT_HOME']

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
@@ -25,7 +25,7 @@ class NUnitBasePlugin implements Plugin<Project> {
             task.dependsOn msbuildTask
             task.conventionMapping.map 'testAssemblies', {
                 msbuildTask.projects.findAll {
-                    it.key =~ 'test'
+                    it.key =~ 'test(s?)\\.dll'
                 }
                 .collect {
                     it.value.getDotnetAssemblyFile()

--- a/src/test/groovy/com/ullink/NUnitPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitPluginTest.groovy
@@ -58,7 +58,10 @@ class NUnitPluginTest {
         expectedException.expect(GradleException.class);
         expectedException.expectMessage("Execution failed for task ':nunit'.")
 
-        project.tasks.nunit.execute()
+        project.tasks.nunit
+                {
+                    nunitVersion = '2.6.4'
+                }.execute()
     }
 
     @Test


### PR DESCRIPTION
Also:
 - increase default nunit runner to 2.9.0
 - only take assemblies matching regex /test(s?).dll/