### PR TITLE
Fix lookup for test dlls

### DIFF
--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
@@ -25,7 +25,7 @@ class NUnitBasePlugin implements Plugin<Project> {
             task.dependsOn msbuildTask
             task.conventionMapping.map 'testAssemblies', {
                 msbuildTask.projects.findAll {
-                    it.key =~ 'test(s?)\\.dll'
+                    it.key =~ '^.+test(s?)$'
                 }
                 .collect {
                     it.value.getDotnetAssemblyFile()


### PR DESCRIPTION
The filter was wrong as it checked against project name for a dll file