### PR TITLE
Migrate tests to spock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 apply plugin: 'groovy'
+apply plugin: 'java-gradle-plugin'
 
 group = 'com.ullink.gradle'
 description 'gradle-nunit-plugin is a Gradle plugin that enables NUnit testing'
@@ -15,6 +16,9 @@ dependencies {
     testCompile 'xmlunit:xmlunit:1.6'
     testCompile 'junit:junit:4.11'
     testCompile 'pl.pragmatists:JUnitParams:1.0.5'
+    testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
+        exclude module: 'groovy-all'
+    }
 }
 
 bintray {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     compile 'org.codehaus.gpars:gpars:1.2.1'
     testCompile 'xmlunit:xmlunit:1.6'
     testCompile 'junit:junit:4.11'
-    testCompile 'pl.pragmatists:JUnitParams:1.0.5'
     testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude module: 'groovy-all'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
     id 'net.researchgate.release' version '2.6.0'
 }
 
-apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
+apply plugin: 'groovy'
 
 group = 'com.ullink.gradle'
 description 'gradle-nunit-plugin is a Gradle plugin that enables NUnit testing'

--- a/src/test/groovy/com/ullink/NUnitPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitPluginTest.groovy
@@ -5,7 +5,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class NUnitPluginTest extends Specification {
     private Project project
@@ -20,25 +19,6 @@ class NUnitPluginTest extends Specification {
             project.tasks.nunit instanceof NUnit
     }
 
-    def "tasks clean and nunit work"() {
-        expect:
-            project.apply plugin: 'base'
-            project.nunit {
-                testAssemblies = ['-help']
-            }
-            project.tasks.clean.execute()
-            project.tasks.nunit.execute()
-    }
-
-    def "tasks nunit works"() {
-        expect:
-            project.nunit {
-                testAssemblies = ['-help']
-            }
-
-            project.tasks.nunit.execute()
-    }
-
     def "nunit task throws exception when no project is specified"() {
         when:
             project.tasks.nunit
@@ -48,19 +28,6 @@ class NUnitPluginTest extends Specification {
         then:
             GradleException exception = thrown()
             exception.message == "Execution failed for task ':nunit'."
-    }
-
-    @Unroll
-    def "execute help works for nunit #version"() {
-        expect:
-            project.nunit {
-                testAssemblies = ['-help']
-                nunitVersion = version
-            }
-
-            project.tasks.nunit.execute()
-        where:
-            version << ['3.0.0', '3.5.0', '3.6.0', '3.6.1']
     }
 
     def "setting report folder works"() {

--- a/src/test/groovy/com/ullink/NUnitPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitPluginTest.groovy
@@ -1,86 +1,75 @@
 package com.ullink
 
 import com.ullink.gradle.nunit.NUnit
-import junitparams.JUnitParamsRunner
-import junitparams.Parameters;
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.ExpectedException
-import org.junit.runner.RunWith;
+import spock.lang.Specification
+import spock.lang.Unroll
 
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.assertEquals
-
-@RunWith(JUnitParamsRunner.class)
-class NUnitPluginTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
+class NUnitPluginTest extends Specification {
     private Project project
 
-    @Before
-    public void init() {
+    def setup() {
         project = ProjectBuilder.builder().build()
         project.apply plugin: 'nunit'
     }
 
-    @Test
-    public void nunitPluginAddsNUnitTaskToProject() {
-        assertTrue(project.tasks.nunit instanceof NUnit)
+    def "nunit plugin adds nunit task to project"() {
+        expect:
+            project.tasks.nunit instanceof NUnit
     }
 
-    @Test
-    public void execution_cleanhelp_works() {
-        project.apply plugin: 'base'
-        project.nunit {
-            testAssemblies = ['-help']
-        }
-
-        project.tasks.clean.execute()
-        project.tasks.nunit.execute()
+    def "tasks clean and nunit work"() {
+        expect:
+            project.apply plugin: 'base'
+            project.nunit {
+                testAssemblies = ['-help']
+            }
+            project.tasks.clean.execute()
+            project.tasks.nunit.execute()
     }
 
-    @Test
-    public void execution_help_works() {
-        project.nunit {
-            testAssemblies = ['-help']
-        }
+    def "tasks nunit works"() {
+        expect:
+            project.nunit {
+                testAssemblies = ['-help']
+            }
 
-        project.tasks.nunit.execute()
+            project.tasks.nunit.execute()
     }
 
-    @Test
-    public void execution_noProject_throwsGradleException() {
-        expectedException.expect(GradleException.class);
-        expectedException.expectMessage("Execution failed for task ':nunit'.")
-
-        project.tasks.nunit
-                {
-                    nunitVersion = '2.6.4'
-                }.execute()
+    def "nunit task throws exception when no project is specified"() {
+        when:
+            project.tasks.nunit
+            {
+                nunitVersion = '2.6.4'
+            }.execute()
+        then:
+            GradleException exception = thrown()
+            exception.message == "Execution failed for task ':nunit'."
     }
 
-    @Test
-    @Parameters(["3.0.0", "3.5.0", "3.6.0", "3.6.1"])
-    public void execute_help_works_for_v3(String version) {
-        project.nunit {
-            testAssemblies = ['-help']
-            nunitVersion = version
-        }
+    @Unroll
+    def "execute help works for nunit #version"() {
+        expect:
+            project.nunit {
+                testAssemblies = ['-help']
+                nunitVersion = version
+            }
 
-        project.tasks.nunit.execute()
+            project.tasks.nunit.execute()
+        where:
+            version << ['3.0.0', '3.5.0', '3.6.0', '3.6.1']
     }
 
-    @Test
-    public void ensures_settingsReportFolder_works() {
-        project.nunit {
-            testAssemblies = ['TestA.dll']
-            reportFolder = './foo'
-        }
-        assertEquals('foo', project.nunit.testReportPath.parentFile.name)
+    def "setting report folder works"() {
+        when:
+            project.nunit {
+                testAssemblies = ['TestA.dll']
+                reportFolder = './foo'
+            }
+        then:
+            'foo' == project.nunit.testReportPath.parentFile.name
     }
 }

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -1,252 +1,252 @@
 package com.ullink
 
-import static groovy.test.GroovyAssert.shouldFail
-
 import org.gradle.api.GradleException
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Test
+import spock.lang.Specification
 
-public class NUnitTest {
-
-    @Test
-    public void getTestInputAsList_works() {
+class NUnitTest extends Specification {
+    def "test input correctly parses lists and comma delimited strings"() {
+        expect:
         def nunit = getNUnitTask()
-        assert nunit.getTestInputAsList('A,B,C') == ['A', 'B', 'C']
-        assert nunit.getTestInputAsList('A') == ['A']
-        assert nunit.getTestInputAsList(['A', 'B', 'C']) == ['A', 'B', 'C']
-        assert nunit.getTestInputAsList(['A']) == ['A']
-
-        def emptyStringList = nunit.getTestInputAsList('')
-        assert (emptyStringList instanceof List)
-        assert !emptyStringList
-
-        def emptyListList = nunit.getTestInputAsList([])
-        assert (emptyListList instanceof List)
-        assert !emptyListList
-
-        def nullList = nunit.getTestInputAsList(null)
-        assert (nullList instanceof List)
-        assert !nullList
+            nunit.getTestInputAsList('A,B,C') == ['A', 'B', 'C']
+            nunit.getTestInputAsList('A') == ['A']
+            nunit.getTestInputAsList(['A', 'B', 'C']) == ['A', 'B', 'C']
+            nunit.getTestInputAsList(['A']) == ['A']
     }
 
-    @Test
-    public void whenNUnit2_getTestInputsAsString_works() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '2.0.0'
-        assert nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
-        assert nunit.getTestInputsAsString('A') == 'A'
-        assert nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A,B,C'
-        assert nunit.getTestInputsAsString(['A']) == 'A'
-        assert nunit.getTestInputsAsString('') == ''
-        assert nunit.getTestInputsAsString([]) == ''
-        assert nunit.getTestInputsAsString(null) == ''
+    def "test input is parsed correctly as List in corner cases"() {
+        when:
+            def nunit = getNUnitTask()
+            def emptyStringList = nunit.getTestInputAsList('')
+            def emptyListList = nunit.getTestInputAsList([])
+            def nullList = nunit.getTestInputAsList(null)
+        then:
+            emptyStringList instanceof List
+            !emptyStringList
+            emptyListList instanceof List
+            !emptyListList
+            nullList instanceof List
+            !nullList
     }
 
-    @Test
-    public void whenNUnit3_getTestInputsAsString_works() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '3.0.0'
-        assert nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
-        assert nunit.getTestInputsAsString('A') == 'A'
-        assert nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A or B or C'
-        assert nunit.getTestInputsAsString(['A']) == 'A'
-        assert nunit.getTestInputsAsString('') == ''
-        assert nunit.getTestInputsAsString([]) == ''
-        assert nunit.getTestInputsAsString(null) == ''
+    def "test input is parsed correctly when using nunit 2"() {
+        when: "Nunit 2 is used"
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '2.0.0'
+        then:
+            nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
+            nunit.getTestInputsAsString('A') == 'A'
+            nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A,B,C'
+            nunit.getTestInputsAsString(['A']) == 'A'
+            nunit.getTestInputsAsString('') == ''
+            nunit.getTestInputsAsString([]) == ''
+            nunit.getTestInputsAsString(null) == ''
     }
 
-    @Test
-    public void whenSingleTest_notParallel_singleTestReport(){
-        def nunit = getNUnitTask()
-        nunit.reportFileName = 'TestResult.xml'
-        nunit.parallelForks = true
-        nunit.run = 'Test1'
-        nunit.reportFolder = './'
-
-        assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
+    def "test input is parsed correctly when using nunit 3"() {
+        when: "nunit 3 is used"
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '3.0.0'
+        then:
+            nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
+            nunit.getTestInputsAsString('A') == 'A'
+            nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A or B or C'
+            nunit.getTestInputsAsString(['A']) == 'A'
+            nunit.getTestInputsAsString('') == ''
+            nunit.getTestInputsAsString([]) == ''
+            nunit.getTestInputsAsString(null) == ''
     }
 
-    @Test
-    public void whenSingleTest_parallel_singleTestReport(){
-        def nunit = getNUnitTask()
-        nunit.reportFileName = 'TestResult.xml'
-        nunit.parallelForks = true
-        nunit.run = 'Test1'
-        nunit.reportFolder = './'
-
-        assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
+    def "a single run in parallel generates one report file"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.reportFileName = 'TestResult.xml'
+            nunit.parallelForks = true
+            nunit.run = 'Test1'
+            nunit.reportFolder = './'
+        then:
+            nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
     }
 
-    @Test
-    public void whenMultipleTests_notParallel_singleTestReport(){
-        def nunit = getNUnitTask()
-        nunit.reportFileName = 'TestResult.xml'
-        nunit.parallelForks = false
-        nunit.run = ['Test1', 'Test2']
-        nunit.reportFolder = './'
-
-        assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
+    def "a single run generates only one report file"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.reportFileName = 'TestResult.xml'
+            nunit.parallelForks = false
+            nunit.run = 'Test1'
+            nunit.reportFolder = './'
+        then:
+            nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
     }
 
-    @Test
-    public void whenMultipleTests_parallel_singleTestReport(){
-        def nunit = getNUnitTask()
-        nunit.reportFileName = 'TestResult.xml'
-        nunit.parallelForks = true
-        nunit.run = ['Test1', 'Test2']
-        nunit.reportFolder = './'
-
-        assert nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
+    def "multiple runs generate only one report file"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.reportFileName = 'TestResult.xml'
+            nunit.parallelForks = false
+            nunit.run = ['Test1', 'Test2']
+            nunit.reportFolder = './'
+        then:
+            nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
     }
 
-    @Test
-    public void whenNUnit2_run_runSpecified() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '2.0.0'
-        nunit.run = ['Test1', 'Test2']
-
-        def commandArgs = nunit.getCommandArgs()
-
-        // list contains does not work with GString
-        assert commandArgs.find { it == '-run:Test1,Test2' }
+    def "multiple runs in parallel generate only one report file"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.reportFileName = 'TestResult.xml'
+            nunit.parallelForks = true
+            nunit.run = ['Test1', 'Test2']
+            nunit.reportFolder = './'
+        then:
+            nunit.getTestReportPath() == new File(nunit.project.projectDir, "TestResult.xml")
     }
 
-    @Test
-    public void whenNUnit2_test_runSpecified() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '2.0.0'
-        nunit.test = ['Test1', 'Test2']
+    def "command args contain runs when using nunit 2"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '2.0.0'
+            nunit.run = ['Test1', 'Test2']
 
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find { it == '-run:Test1,Test2' }
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            // list contains does not work with GString
+            commandArgs.find { it == '-run:Test1,Test2' }
     }
 
-    @Test
-    public void whenNUnit3_where_whereSpecified() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '3.0.0'
-        nunit.where = [ 'test == \'Test1\'', 'test == \'Test2\'']
+    def "command args contain tests when using nunit 2"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '2.0.0'
+            nunit.test = ['Test1', 'Test2']
 
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find { it == '-where:test == \'Test1\' or test == \'Test2\'' }
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            commandArgs.find { it == '-run:Test1,Test2' }
     }
 
-    @Test
-    public void whenNUnit3_test_whereSpecified() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '3.0.0'
-        nunit.test = ['Test1', 'Test2']
+    def "command args contain where when using nunit 3"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '3.0.0'
+            nunit.where = [ 'test == \'Test1\'', 'test == \'Test2\'']
 
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find { it == '-where:test == \'Test1\' or test == \'Test2\'' }
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            commandArgs.find { it == '-where:test == \'Test1\' or test == \'Test2\'' }
     }
 
-    @Test
-    public void whenNUnit3_run_whereSpecified() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '3.0.0'
-        nunit.run = ['Test1', 'Test2']
+    def "command args contain test when using nunit 3"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '3.0.0'
+            nunit.test = ['Test1', 'Test2']
 
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find {it == '-where:test == \'Test1\' or test == \'Test2\'' }
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            commandArgs.find { it == '-where:test == \'Test1\' or test == \'Test2\'' }
     }
 
-    @Test
-    public void whenNUnit2_include_shouldPass() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '2.0.0'
-        nunit.include = 'foo'
+    def "command args contain runs when using nunit 3"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '3.0.0'
+            nunit.run = ['Test1', 'Test2']
 
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find { it == '-include:foo' }
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            commandArgs.find {it == '-where:test == \'Test1\' or test == \'Test2\'' }
     }
 
-    @Test
-    public void whenNUnit3_include_shouldFail() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '3.0.0'
-
-        shouldFail(GradleException) {
+    def "command args contain include when using nunit 2"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '2.0.0'
             nunit.include = 'foo'
-        }
+
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            commandArgs.find { it == '-include:foo' }
     }
 
-    @Test
-    public void whenNUnit3_shadowcopy_shadowcopy() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '3.0.0'
-        nunit.shadowCopy = true
-
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find { it == '-shadowcopy' }
+    def "exception is thrown when calling include on nunit 3"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '3.0.0'
+            nunit.include = 'foo'
+        then:
+            thrown GradleException
     }
 
-    @Test
-    public void whenNUnit2_notShadowcopy_noshadow() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '2.0.0'
-        nunit.shadowCopy = false
+    def "command args contain shadow copy attribute on nunit 3"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '3.0.0'
+            nunit.shadowCopy = true
 
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find { it == '-noshadow' }
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            commandArgs.find { it == '-shadowcopy' }
     }
 
-    @Test
-    public void whenNUnit3_AllLabels_AlllabelsIsPassed() {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '3.0.2'
-        nunit.labels = 'All'
+    def "command args contain noshadow attribute on nunit 2"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '2.0.0'
+            nunit.shadowCopy = false
 
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find { it == '-labels:All' }
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            commandArgs.find { it == '-noshadow' }
     }
 
-    @Test
-    public void whenNUnit3_setResultFormat_resultFormatIsSet()
-    {
-        def nunit = getNUnitTask()
-        nunit.nunitVersion = '3.0.1'
-        nunit.resultFormat = 'nunit3'
+    def "command args contain all labels"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '3.0.2'
+            nunit.labels = 'All'
 
-        def commandArgs = nunit.getCommandArgs()
-
-        assert commandArgs.find { it =~ /-result:.*TestResult\.xml;format=nunit3/ }
+            def commandArgs = nunit.getCommandArgs()
+        then:
+            commandArgs.find { it == '-labels:All' }
     }
 
-    @Test
-    public void whenRun_withDefaultCommandModifier_setsPathAndBuildArgs()
-    {
-        def nunit = getNUnitTask()
+    def "command args contain result format"() {
+        when:
+            def nunit = getNUnitTask()
+            nunit.nunitVersion = '3.0.1'
+            nunit.resultFormat = 'nunit3'
 
-        def cmdLine = nunit.getCommandLine('input', 'path')
+            def commandArgs = nunit.getCommandArgs()
 
-        assert cmdLine == [nunit.getNunitExec().absolutePath, *nunit.buildCommandArgs('input', 'path')]
+        then:
+            commandArgs.find { it =~ /-result:.*TestResult\.xml;format=nunit3/ }
     }
 
-    @Test
-    public void whenRun_withCustomCommandModifier_setsPathAndBuildArgsWithCustomArguments() {
-        def nunit = getNUnitTask()
+    def "running with default command modifier sets path and build args"() {
+        when:
+            def nunit = getNUnitTask()
 
-        nunit.nunitCommandModifier = { path, args ->
-            ['dotMemoryUnit.exe', path, 'custom-args', *args]
-        }
+            def cmdLine = nunit.getCommandLine('input', 'path')
+        then:
+            cmdLine == [nunit.getNunitExec().absolutePath, *nunit.buildCommandArgs('input', 'path')]
+    }
 
-        def cmdLine = nunit.getCommandLine('input', 'path')
+    def "running with custom command modifier sets path and build args with custom arguments"() {
+        when:
+            def nunit = getNUnitTask()
 
-        assert cmdLine == [
-                'dotMemoryUnit.exe',
-                nunit.getNunitExec().absolutePath,
-                'custom-args',
-                *nunit.buildCommandArgs('input', 'path')
-        ]
+            nunit.nunitCommandModifier = { path, args ->
+                ['dotMemoryUnit.exe', path, 'custom-args', *args]
+            }
+
+            def cmdLine = nunit.getCommandLine('input', 'path')
+        then:
+            cmdLine == [
+                    'dotMemoryUnit.exe',
+                    nunit.getNunitExec().absolutePath,
+                    'custom-args',
+                    *nunit.buildCommandArgs('input', 'path')
+            ]
     }
 
     def getNUnitTask() {

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -6,8 +6,9 @@ import spock.lang.Specification
 
 class NUnitTest extends Specification {
     def "test input correctly parses lists and comma delimited strings"() {
+        given:
+            def nunit = getNUnitTask()
         expect:
-        def nunit = getNUnitTask()
             nunit.getTestInputAsList('A,B,C') == ['A', 'B', 'C']
             nunit.getTestInputAsList('A') == ['A']
             nunit.getTestInputAsList(['A', 'B', 'C']) == ['A', 'B', 'C']
@@ -15,8 +16,9 @@ class NUnitTest extends Specification {
     }
 
     def "test input is parsed correctly as List in corner cases"() {
-        when:
+        given:
             def nunit = getNUnitTask()
+        when:
             def emptyStringList = nunit.getTestInputAsList('')
             def emptyListList = nunit.getTestInputAsList([])
             def nullList = nunit.getTestInputAsList(null)
@@ -30,10 +32,10 @@ class NUnitTest extends Specification {
     }
 
     def "test input is parsed correctly when using nunit 2"() {
-        when: "Nunit 2 is used"
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '2.0.0'
-        then:
+        expect:
             nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
             nunit.getTestInputsAsString('A') == 'A'
             nunit.getTestInputsAsString(['A', 'B', 'C']) == 'A,B,C'
@@ -44,8 +46,9 @@ class NUnitTest extends Specification {
     }
 
     def "test input is parsed correctly when using nunit 3"() {
-        when: "nunit 3 is used"
+        given:
             def nunit = getNUnitTask()
+        when: "nunit 3 is used"
             nunit.nunitVersion = '3.0.0'
         then:
             nunit.getTestInputsAsString('A,B,C') == 'A,B,C'
@@ -58,8 +61,9 @@ class NUnitTest extends Specification {
     }
 
     def "a single run in parallel generates one report file"() {
-        when:
+        given:
             def nunit = getNUnitTask()
+        when:
             nunit.reportFileName = 'TestResult.xml'
             nunit.parallelForks = true
             nunit.run = 'Test1'
@@ -69,8 +73,9 @@ class NUnitTest extends Specification {
     }
 
     def "a single run generates only one report file"() {
-        when:
+        given:
             def nunit = getNUnitTask()
+        when:
             nunit.reportFileName = 'TestResult.xml'
             nunit.parallelForks = false
             nunit.run = 'Test1'
@@ -80,8 +85,9 @@ class NUnitTest extends Specification {
     }
 
     def "multiple runs generate only one report file"() {
-        when:
+        given:
             def nunit = getNUnitTask()
+        when:
             nunit.reportFileName = 'TestResult.xml'
             nunit.parallelForks = false
             nunit.run = ['Test1', 'Test2']
@@ -91,8 +97,9 @@ class NUnitTest extends Specification {
     }
 
     def "multiple runs in parallel generate only one report file"() {
-        when:
+        given:
             def nunit = getNUnitTask()
+        when:
             nunit.reportFileName = 'TestResult.xml'
             nunit.parallelForks = true
             nunit.run = ['Test1', 'Test2']

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -102,11 +102,11 @@ class NUnitTest extends Specification {
     }
 
     def "command args contain runs when using nunit 2"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '2.0.0'
             nunit.run = ['Test1', 'Test2']
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             // list contains does not work with GString
@@ -114,108 +114,109 @@ class NUnitTest extends Specification {
     }
 
     def "command args contain tests when using nunit 2"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '2.0.0'
             nunit.test = ['Test1', 'Test2']
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             commandArgs.find { it == '-run:Test1,Test2' }
     }
 
     def "command args contain where when using nunit 3"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '3.0.0'
             nunit.where = [ 'test == \'Test1\'', 'test == \'Test2\'']
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             commandArgs.find { it == '-where:test == \'Test1\' or test == \'Test2\'' }
     }
 
     def "command args contain test when using nunit 3"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '3.0.0'
             nunit.test = ['Test1', 'Test2']
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             commandArgs.find { it == '-where:test == \'Test1\' or test == \'Test2\'' }
     }
 
     def "command args contain runs when using nunit 3"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '3.0.0'
             nunit.run = ['Test1', 'Test2']
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             commandArgs.find {it == '-where:test == \'Test1\' or test == \'Test2\'' }
     }
 
     def "command args contain include when using nunit 2"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '2.0.0'
             nunit.include = 'foo'
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             commandArgs.find { it == '-include:foo' }
     }
 
     def "exception is thrown when calling include on nunit 3"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '3.0.0'
+        when:
             nunit.include = 'foo'
         then:
             thrown GradleException
     }
 
     def "command args contain shadow copy attribute on nunit 3"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '3.0.0'
             nunit.shadowCopy = true
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             commandArgs.find { it == '-shadowcopy' }
     }
 
     def "command args contain noshadow attribute on nunit 2"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '2.0.0'
             nunit.shadowCopy = false
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             commandArgs.find { it == '-noshadow' }
     }
 
     def "command args contain all labels"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '3.0.2'
             nunit.labels = 'All'
-
+        when:
             def commandArgs = nunit.getCommandArgs()
         then:
             commandArgs.find { it == '-labels:All' }
     }
 
     def "command args contain result format"() {
-        when:
+        given:
             def nunit = getNUnitTask()
             nunit.nunitVersion = '3.0.1'
             nunit.resultFormat = 'nunit3'
-
+        when:
             def commandArgs = nunit.getCommandArgs()
 
         then:

--- a/src/test/groovy/com/ullink/functional/NUnitPluginFunctionalTest.groovy
+++ b/src/test/groovy/com/ullink/functional/NUnitPluginFunctionalTest.groovy
@@ -1,0 +1,87 @@
+package com.ullink.functional
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NUnitPluginFunctionalTest extends Specification {
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+
+    def setup() {
+        buildFile = testProjectDir.newFile('build.gradle')
+        buildFile << """
+            plugins {
+                id 'base'
+                id 'nunit'
+            }
+        """
+    }
+
+    def "nunit task successfully delegates -help to nunit-console-runner"() {
+        given: "-help command and the default nunit version"
+            buildFile << """
+                nunit {
+                    testAssemblies = ['-help']
+                }
+            """
+        when: "clean and nunit tasks are executed"
+            def result = GradleRunner.create()
+                    .withProjectDir(testProjectDir.root)
+                    .withArguments('clean', 'nunit')
+                    .withPluginClasspath()
+                    .withDebug(true)
+                    .build()
+        then: "help command was written for the default nunit version"
+            result.output.contains('NUnit Console Runner 3.9.0')
+            result.task(':clean').outcome == TaskOutcome.UP_TO_DATE
+            result.task(':nunit').outcome == TaskOutcome.SUCCESS
+    }
+
+    @Unroll
+    def "execute help works for nunit #version"() {
+        given: "gradle build file with specific version"
+            buildFile << """
+                    nunit {
+                        testAssemblies = ['-help']
+                        nunitVersion = '$version'
+                    }
+                """
+        when: "nunit task is executed"
+            def result = GradleRunner.create()
+                    .withProjectDir(testProjectDir.root)
+                    .withArguments( 'nunit')
+                    .withPluginClasspath()
+                    .withDebug(true)
+                    .build()
+        then: "help command was written for the specified nunit version"
+            result.output.contains("NUnit Console Runner $version")
+            result.output.contains("NUNIT3-CONSOLE [inputfiles] [options]")
+            result.task(':nunit').outcome == TaskOutcome.SUCCESS
+        where:
+            version << ['3.5.0', '3.6.0', '3.6.1']
+    }
+
+    def "execute help works for 3.0.0 version"() {
+        given:
+            buildFile << """
+                    nunit {
+                        testAssemblies = ['-help']
+                        nunitVersion = '3.0.0'
+                    }
+                """
+        when:
+            def result = GradleRunner.create()
+                    .withProjectDir(testProjectDir.root)
+                    .withArguments( 'nunit')
+                    .withPluginClasspath()
+                    .withDebug(true)
+                    .build()
+        then:
+            result.output.contains("NUnit Console Runner 3.0.5797")
+            result.task(':nunit').outcome == TaskOutcome.SUCCESS
+    }
+}


### PR DESCRIPTION
* Migrate all existing tests to spock
* Rewrite some tests from NUnitPluginTests using TestKit. This is needed because the Task.execute() method was removed in gradle 5.0, and the recommended way for this kind of tests is TestKit.
* With TestKit we can also specify a certain gradle version, therefore test the code with both old and newer versions, depends on what compatibility is required.
