### PR TITLE
Update to gradle 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # gradle-nunit-plugin changelog
 
+## 2.00
+### Breaking change
+* rename timeout to testCaseTimeout due to conflict with AbstractTask after update to Gradle 5.0
+### Changed
+* build with gradle 5.0
+
 ## 1.14
 ### Fixed
 * test binaries are now correctly found

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.15
+version = 2.00

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -26,7 +26,7 @@ class NUnit extends ConventionTask {
     def framework
     def verbosity
     def config
-    def timeout
+    def testCaseTimeout
     def labels
 
     def reportFolder
@@ -89,10 +89,14 @@ class NUnit extends ConventionTask {
     void setNunitVersion(def version) {
         this.nunitVersion = version
         if (getIsV3(version)) {
+            this.metaClass = new ExpandoMetaClass(NUnit.class, false, false)
             this.metaClass.mixin NUnit3Mixins
+            this.metaClass.initialize()
         }
         else {
+            this.metaClass = new ExpandoMetaClass(NUnit.class, false, false)
             this.metaClass.mixin NUnit2Mixins
+            this.metaClass.initialize()
         }
     }
 
@@ -343,8 +347,8 @@ class NUnit extends ConventionTask {
         if (labels) {
             commandLineArgs += "-labels:$labels"
         }
-        if (timeout) {
-            commandLineArgs += "-timeout:$timeout"
+        if (testCaseTimeout) {
+            commandLineArgs += "-timeout:$testCaseTimeout"
         }
         if (logFile) {
             commandLineArgs += "-output:${getTestLogFile().getPath()}"

--- a/src/test/groovy/com/ullink/NUnitPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitPluginTest.groovy
@@ -3,6 +3,7 @@ package com.ullink
 import com.ullink.gradle.nunit.NUnit
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.process.internal.ExecException
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -24,10 +25,10 @@ class NUnitPluginTest extends Specification {
             project.tasks.nunit
             {
                 nunitVersion = '2.6.4'
-            }.execute()
+            }.build()
         then:
-            GradleException exception = thrown()
-            exception.message == "Execution failed for task ':nunit'."
+            ExecException exception = thrown()
+            exception.message.contains("finished with non-zero exit value")
     }
 
     def "setting report folder works"() {


### PR DESCRIPTION
 AbstractTask now has a timeout field, so we need to rename
the NUnit timeout field to testCaseTimeout

 execute() method was removed from Task, we can call build() instead
for simple tests, the functional tests should be TestKit

 Something changed in metaClass.mixins. Even if we set the metaClass.mixin
to NUnit2Mixins class it keeps calling methods from NUnit3Mixin.
To avoid this we now instantiate a new ExpandoMetaClass everytime
we change the metaClass.mixin attribute.

 Running nunit 2 test case without project now throws ExecException instead of
GradleException

Considering there's a breaking change for the timeout field, should I update the major version for release?