### PR TITLE
Generate report file based on TestResult

### DIFF
--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -299,7 +299,7 @@ class NUnit extends ConventionTask {
             if (env)
                 environment env
             commandLine = commandLineExec
-            ignoreExitValue = ignoreFailures
+            ignoreExitValue = true
         }
 
         int exitValue = mbr.exitValue
@@ -307,12 +307,14 @@ class NUnit extends ConventionTask {
             return
         }
 
-        boolean anyTestFailing = exitValue > 0
-        if (anyTestFailing && ignoreFailures) {
+        if (exitValue > 0) {
+            //failed tests but no error
+            if (!ignoreFailures) {
+                throw new GradleException("There are failing tests (exitCode = ${mbr.exitValue})")
+            }
             return
         }
-
-        throw new GradleException("${getNunitExec()} execution failed (ret=${mbr.exitValue})");
+        throw new GradleException("${getNunitExec()} execution failed (exitCode = ${mbr.exitValue})")
     }
 
     def prepareExecute() {

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitPlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitPlugin.groovy
@@ -9,6 +9,10 @@ class NUnitPlugin implements Plugin<Project> {
         project.apply plugin: 'nunit-base'
 
         Task defaultNUnitTask = project.task('nunit', type: NUnit)
+
+        Task reportingTask = project.task('nunitReport', type: ReportGenerator)
+        defaultNUnitTask.finalizedBy(reportingTask)
+
         defaultNUnitTask.description = 'Executes NUnit tests'
     }
 }

--- a/src/main/groovy/com/ullink/gradle/nunit/ReportGenerator.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/ReportGenerator.groovy
@@ -1,0 +1,116 @@
+package com.ullink.gradle.nunit
+
+import org.gradle.api.tasks.Exec
+
+class ReportGenerator extends Exec {
+
+    def ExtentReportType = 'v3html'
+    def ExtentReportDownloadUrl = 'https://github.com/extent-framework/extentreports-dotnet-cli/archive'
+    def ExtentReportZipName = 'master.zip'
+    def ExtentReportExecutablePath = 'extentreports-dotnet-cli-master/dist/extent.exe'
+
+    @Override
+    protected void exec() {
+        if (isTestResultFileAvailable()) {
+            project.logger.info("Generating the report for the Test Results..")
+
+            ensureExtentReportIsAvailable()
+            generateReports()
+        } else {
+            project.logger.info("There is no available Test Result file based on which the report should be generated!")
+        }
+    }
+
+    boolean isTestResultFileAvailable() {
+        NUnit nunit = project.tasks.nunit
+
+        File testResultPath = nunit.getTestReportPath()
+        if (!testResultPath.exists()) {
+            return false
+        }
+        return true
+    }
+
+    void ensureExtentReportIsAvailable() {
+        if (!isExtentReportAvailable()) {
+            project.logger.info "Downloading extent report..."
+
+            getCacheDirForExtentReport().mkdirs()
+            downloadExtentReport()
+        }
+    }
+
+    boolean isExtentReportAvailable() {
+        def extentReportCacheDir = getCacheDirForExtentReport()
+        if (!extentReportCacheDir.exists()) {
+            return false
+        }
+
+        def extentReportExecutable = new File(extentReportCacheDir, ExtentReportExecutablePath)
+        if (!extentReportExecutable.exists()) {
+            return false
+        }
+
+        return true
+    }
+
+    File getCacheDirForExtentReport() {
+        new File(new File(project.gradle.gradleUserHomeDir, 'caches'), 'extent-report')
+    }
+
+    private def generateReports() {
+        NUnit nunit = project.tasks.nunit
+
+        project.exec {
+            commandLine = buildCommandForExtentReport(nunit.getTestReportPath(), nunit.getReportFolder())
+        }
+
+        def resultFile = new File(nunit.getReportFolder(), "index.html")
+        resultFile.renameTo new File(nunit.getReportFolder(), 'TestResult.html')
+    }
+
+    def buildCommandForExtentReport(def testResultPath, def outputFolder) {
+        def commandLineArgs = []
+
+        commandLineArgs += getExtentReportExeFile().absolutePath
+
+        commandLineArgs += "-i"
+        commandLineArgs += testResultPath
+
+        commandLineArgs += "-o"
+        commandLineArgs += outputFolder
+
+        commandLineArgs += "-r"
+        commandLineArgs += ExtentReportType
+
+        commandLineArgs
+    }
+
+    File getExtentReportExeFile() {
+        def extentReportFolder = getCacheDirForExtentReport()
+        return new File(extentReportFolder, ExtentReportExecutablePath)
+    }
+
+    void downloadExtentReport() {
+        def downloadedFile = new File(getTemporaryDir(), ExtentReportZipName)
+        def extentReportDownloadUrl = getExtentReportDownloadUrl()
+        def zipOutputDir = getCacheDirForExtentReport()
+
+        project.logger.info "Downloading & Unpacking Extent Report from ${extentReportDownloadUrl}"
+
+        project.download {
+            src "$extentReportDownloadUrl"
+            dest downloadedFile
+        }
+
+        project.copy {
+            from project.zipTree(downloadedFile)
+            into zipOutputDir
+        }
+    }
+
+    String getExtentReportDownloadUrl() {
+        // As there is no current release for extent-report we integrate the master version
+        return "${ExtentReportDownloadUrl}/$ExtentReportZipName"
+    }
+}

--- a/src/test/groovy/com/ullink/NUnitPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitPluginTest.groovy
@@ -1,6 +1,7 @@
 package com.ullink
 
 import com.ullink.gradle.nunit.NUnit
+import com.ullink.gradle.nunit.ReportGenerator
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.process.internal.ExecException
@@ -20,6 +21,11 @@ class NUnitPluginTest extends Specification {
             project.tasks.nunit instanceof NUnit
     }
 
+    def "nunit plugin adds nunitReport task to project"() {
+        expect:
+        project.tasks.nunitReport instanceof ReportGenerator
+    }
+
     def "nunit task throws exception when no project is specified"() {
         when:
             project.tasks.nunit
@@ -27,8 +33,8 @@ class NUnitPluginTest extends Specification {
                 nunitVersion = '2.6.4'
             }.build()
         then:
-            ExecException exception = thrown()
-            exception.message.contains("finished with non-zero exit value")
+            GradleException exception = thrown()
+            exception.message.isEmpty() == false
     }
 
     def "setting report folder works"() {

--- a/src/test/groovy/com/ullink/ReportGeneratorTest.groovy
+++ b/src/test/groovy/com/ullink/ReportGeneratorTest.groovy
@@ -1,0 +1,48 @@
+package com.ullink
+
+import java.nio.file.Paths
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class ReportGeneratorTest extends Specification {
+
+    private static File GradleUserHomeDir = new File("path", "GradleHomeDirForTests")
+
+    def "generating reports with Extent Report has the correct build arguments"() {
+        given:
+            def nunitReportGenerationTask = getReportGenerationTask()
+            def testResultFile = new File("TestResult.xml")
+            def reportOutputFolder = new File("reports/results")
+        when:
+            def extentReportCommandArgument = nunitReportGenerationTask.buildCommandForExtentReport(testResultFile, reportOutputFolder)
+        then:
+            extentReportCommandArgument == [nunitReportGenerationTask.getExtentReportExeFile().absolutePath, '-i', testResultFile, '-o', reportOutputFolder, '-r', 'v3html']
+    }
+
+    def "extent report executable has the correct path"() {
+        given:
+            def nunitReportGenerationTask = getReportGenerationTask()
+        when:
+            def extentReportExecutable = nunitReportGenerationTask.getExtentReportExeFile()
+        then:
+            def pathToTheExecutable = Paths.get("path", "GradleHomeDirForTests", "caches", "extent-report", "extentreports-dotnet-cli-master", "dist", "extent.exe")
+            extentReportExecutable.absolutePath
+                    .contains(pathToTheExecutable.normalize().toString())
+    }
+
+    def "extent report download URL is build correctly"() {
+        given:
+            def nunitReportGenerationTask = getReportGenerationTask()
+        when:
+            def extentReportDownloadUrl = nunitReportGenerationTask.getExtentReportDownloadUrl()
+        then:
+            extentReportDownloadUrl == "https://github.com/extent-framework/extentreports-dotnet-cli/archive/master.zip"
+    }
+
+
+    def getReportGenerationTask() {
+        def project = ProjectBuilder.builder().withGradleUserHomeDir(GradleUserHomeDir).build()
+        project.apply plugin: 'nunit'
+        return project.tasks.nunitReport
+    }
+}

--- a/src/test/groovy/com/ullink/functional/NUnitPluginFunctionalTest.groovy
+++ b/src/test/groovy/com/ullink/functional/NUnitPluginFunctionalTest.groovy
@@ -84,4 +84,23 @@ class NUnitPluginFunctionalTest extends Specification {
             result.output.contains("NUnit Console Runner 3.0.5797")
             result.task(':nunit').outcome == TaskOutcome.SUCCESS
     }
+
+    def "nunitReport task is executed once nunit task is finished"() {
+        given:
+            buildFile << """
+                    nunit {
+                        testAssemblies = ['-help']
+                        nunitVersion = '3.9.0'
+                    }
+                """
+        when:
+            def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments( 'nunit')
+                .withPluginClasspath()
+                .withDebug(true)
+                .build()
+        then:
+            result.output.contains('nunitReport')
+    }
 }


### PR DESCRIPTION
- use the extent-report framework
- generate report once NUnit finished
generating the report
- set the ignoreFailures to true by default
because if an exception is thrown the task
will not be finalized by generating the report;
however take the flag into consideration a bit
later in the workflow
- added unit tests for report generation