### PR TITLE
Fixed download and changed default for version 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or, when using Gradle lower than 2.1:
 It creates a task 'nunit' that may be configured as follows:
 
     nunit {
-        // optional - defaults to '3.9.0', but plugin is compatible with v3+ as well
+        // optional - defaults to '3.10.0', but plugin is compatible with v3+ as well
         // for compatibility reason, nunitVersion should be set (if needed) before applying version specific parameters
         nunitVersion
         // optional - defaults to 'https://github.com/nunit/nunit-console/releases/download'

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -71,9 +71,14 @@ class NUnit extends ConventionTask {
         major == 3 && minor >= 5
     }
 
-    boolean getIsV39() {
+    boolean getIsV39OrAbove() {
         def (major, minor, patch) = getNunitVersion().tokenize('.')*.toInteger()
-        major == 3 && minor == 9
+        major == 3 && minor >= 9
+    }
+
+    boolean getIsV310OrAbove() {
+        def (major, minor, patch) = getNunitVersion().tokenize('.')*.toInteger()
+        major == 3 && minor >= 10
     }
 
     String getGitHubRepoName() {
@@ -112,7 +117,14 @@ class NUnit extends ConventionTask {
             ensureNunitInstalled()
             nunitFolder = getCachedNunitDir()
         }
-        new File(project.file(nunitFolder), "${isV35OrAbove ? '' : 'bin/'}${file}")
+
+        String folderName = "bin/"
+        if (isV310OrAbove) {
+            folderName = "bin/net35/"
+        } else if (isV35OrAbove) {
+            folderName = ""
+        }
+        new File(project.file(nunitFolder), "${folderName}${file}")
     }
 
     void ensureNunitInstalled() {
@@ -149,7 +161,7 @@ class NUnit extends ConventionTask {
         String version = getNunitVersion()
         if (isV35OrAbove && version.endsWith('.0')) {
             version = version.take(version.length() - 2)
-            if (isV39) {
+            if (isV39OrAbove) {
                 version = "v${version}"
             }
         }

--- a/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnitBasePlugin.groovy
@@ -13,7 +13,7 @@ class NUnitBasePlugin implements Plugin<Project> {
 
     def applyNunitConventions(NUnit task, Project project) {
         task.conventionMapping.map "nunitDownloadUrl", { "https://github.com/nunit/${task.gitHubRepoName}/releases/download" }
-        task.conventionMapping.map "nunitVersion", { '3.9.0' }
+        task.conventionMapping.map "nunitVersion", { '3.10.0' }
         task.conventionMapping.map "nunitHome", {
             if (System.getenv()['NUNIT_HOME']) {
                 return System.getenv()['NUNIT_HOME']

--- a/src/test/groovy/com/ullink/functional/NUnitPluginFunctionalTest.groovy
+++ b/src/test/groovy/com/ullink/functional/NUnitPluginFunctionalTest.groovy
@@ -36,7 +36,7 @@ class NUnitPluginFunctionalTest extends Specification {
                     .withDebug(true)
                     .build()
         then: "help command was written for the default nunit version"
-            result.output.contains('NUnit Console Runner 3.9.0')
+            result.output.contains('NUnit Console Runner 3.10.0')
             result.task(':clean').outcome == TaskOutcome.UP_TO_DATE
             result.task(':nunit').outcome == TaskOutcome.SUCCESS
     }


### PR DESCRIPTION
Fixed download for version 3.10
Changed default to version 3.10

It seems that they are continuing with the "v" in the URL so I have expanded the isV39 check.

V3.10 has a new folder structure. The binary file is located in both the net20 and net35 folder so I picked net35 since it's a newer target. Optionally this should be a new config option with a default of net35 so let me know if this is wanted and I'll implement it.

P.s this is my first PR and my first time doing Groovy, so let me know if something needs to be done differently.