### PR TITLE
Fixed issues with download of NUnit 3.11.1

### DIFF
--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -159,8 +159,11 @@ class NUnit extends ConventionTask {
 
     String getFixedDownloadVersion() {
         String version = getNunitVersion()
-        if (isV35OrAbove && version.endsWith('.0')) {
-            version = version.take(version.length() - 2)
+        if (isV35OrAbove) {
+            if(version.endsWith('.0')) {
+                version = version.take(version.length() - 2)
+            }
+
             if (isV39OrAbove) {
                 version = "v${version}"
             }

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -15,6 +15,21 @@ class NUnitTest extends Specification {
             nunit.getTestInputAsList(['A']) == ['A']
     }
 
+    def "test version generates correct fixed download version"(String version, String result) {
+        given:
+            def nunit = getNUnitTask()
+        when:
+            nunit.nunitVersion = version
+        then:
+            nunit.getFixedDownloadVersion() == result
+        where:
+            version | result
+            "2.0.0" | "2.0.0"
+            "3.5.0" | "3.5"
+            "3.9.0" | "v3.9"
+            "3.11.1" | "v3.11.1"
+    }
+
     def "test input is parsed correctly as List in corner cases"() {
         given:
             def nunit = getNUnitTask()


### PR DESCRIPTION
Changed so logic gets applied for all version of NUnit greater than 3.5.
Added new test to test the changed logic.