### PR TITLE
Fix download url for 3.13

### DIFF
--- a/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
+++ b/src/main/groovy/com/ullink/gradle/nunit/NUnit.groovy
@@ -125,6 +125,12 @@ class NUnit extends ConventionTask {
     }
 
     @Internal
+    boolean getIsV3_13OrAbove() {
+        def (major, minor, _) = getNunitVersion().tokenize('.')*.toInteger()
+        major == 3 && minor >= 13
+    }
+
+    @Internal
     boolean getIsV3_14OrAbove() {
         def (major, minor, _) = getNunitVersion().tokenize('.')*.toInteger()
         major == 3 && minor >= 14
@@ -238,14 +244,11 @@ class NUnit extends ConventionTask {
     @Internal
     String getFixedDownloadVersion() {
         String version = getNunitVersion()
-        if (isV3_5OrAbove && !isV3_14OrAbove) {
-            if(version.endsWith('.0')) {
-                version = version.take(version.length() - 2)
-            }
-
-            if (isV3_9OrAbove) {
-                version = "v${version}"
-            }
+        if (isV3_9OrAbove && !isV3_13OrAbove) {
+            version = "v${version}"
+        }
+        if (isV3_5OrAbove && !isV3_14OrAbove && version.endsWith('.0')) {
+            version = version.take(version.length() - 2)
         }
 
         version

--- a/src/test/groovy/com/ullink/NUnitTest.groovy
+++ b/src/test/groovy/com/ullink/NUnitTest.groovy
@@ -28,16 +28,17 @@ class NUnitTest extends Specification {
             '3.2.0' | "bin\\something.exe"
             '3.5.0' | "something.exe"
             '3.5.1' | "something.exe"
+            '4.5.9' | "bin\\something.exe"
             '3.6.1' | "something.exe"
             '3.10.0'| "bin\\net35\\something.exe"
             '3.15.2'| "bin\\net35\\something.exe"
             '3.16.0'| "bin\\something.exe"
             '3.16.3'| "bin\\something.exe"
             //next ones are fake version to pass/fail when logic for new versions is added
-            '3.17.0'| "bin\\something.exe"
-            '3.18.0'| "bin\\something.exe"
-            '3.19.0'| "bin\\something.exe"
-            '4.5.9' | "bin\\something.exe"
+            '3.17.0'| "bin\\net35\\something.exe"
+            '3.18.0'| "bin\\net462\\something.exe"
+            '3.19.0'| "bin\\net462\\something.exe"
+            '3.20.1'| "bin\\net462\\something.exe"
     }
 
     def "test version generates correct fixed download version"(String version, String result) {
@@ -53,6 +54,10 @@ class NUnitTest extends Specification {
             "3.5.0" | "3.5"
             "3.9.0" | "v3.9"
             "3.11.1" | "v3.11.1"
+            "3.12.0" | "v3.12"
+            "3.13.0" | "3.13"
+            "3.13.1" | "3.13.1"
+            "3.14.0" | "3.14.0"
     }
 
     def "test input is parsed correctly as List in corner cases"() {

--- a/src/test/groovy/com/ullink/functional/NUnitPluginFunctionalTest.groovy
+++ b/src/test/groovy/com/ullink/functional/NUnitPluginFunctionalTest.groovy
@@ -7,12 +7,25 @@ import spock.lang.Specification
 import spock.lang.TempDir
 import spock.lang.Unroll
 
+import java.nio.file.Paths
+
 class NUnitPluginFunctionalTest extends Specification {
     @TempDir
     File testProjectDir
     File buildFile
 
     def setup() {
+        def cachesDir = Paths.get(System.getProperty("user.home"), ".gradle", "caches", "nunit").toFile()
+        if (cachesDir.exists()) {
+            println "Cleaning up caches directory: $cachesDir"
+            cachesDir.eachDir { File dir ->
+                println "Deleting directory: $dir"
+                FileUtils.deleteDirectory(dir)
+            }
+        } else {
+            println "Caches directory does not exist: $cachesDir, no cleanup needed"
+        }
+
         buildFile = testProjectDir.toPath().resolve('build.gradle').toFile()
         buildFile << """
             plugins {
@@ -64,7 +77,7 @@ class NUnitPluginFunctionalTest extends Specification {
             result.output.contains("NUNIT3-CONSOLE [inputfiles] [options]")
             result.task(':nunit').outcome == TaskOutcome.SUCCESS
         where:
-            version << ['3.16.1', '3.14.0', '3.13.2']
+            version << ['3.16.1', '3.14.0', '3.13.2', '3.13.0', '3.12.0', '3.11.1', '3.11.0', '3.10.0', '3.9.0', '3.8.0']
     }
 
     def "nunit for two parallel namespaces successfully creates the merged TestResult.xml"() {


### PR DESCRIPTION
Issue introduced by previous commit.
For 3.13.x there should be no "v." prefix
Fix some broken UTs